### PR TITLE
Process partially transferred runs.

### DIFF
--- a/run2pp/DST_STREAMING_EVENT_run2pp_ana441_2024p007.yaml
+++ b/run2pp/DST_STREAMING_EVENT_run2pp_ana441_2024p007.yaml
@@ -22,7 +22,7 @@ DST_STREAMING_EVENT_run2pp:
       direct_path: /sphenix/lustre01/sphnxpro/{mode}/*/physics/
       query: |-
          with run2pp as (
-              select 43249 as firstrun,
+              select 51428 as firstrun,
                      53880 as lastrun
          ),
          fullrun as (
@@ -36,11 +36,11 @@ DST_STREAMING_EVENT_run2pp:
                 filelist,run2pp
          where 
            ( 
-             (filename  like '/bbox%/TPC%physics%.evt'   and lastevent>2 ) or
-             (filename  like '/bbox%/TPOT%physics%.evt'  and lastevent>2 ) or
-             (filename  like '/bbox%/physics_intt%.evt'  and lastevent>2 ) or
-             (filename  like '/bbox%/GL1_physics%.evt'   and lastevent>2 ) or
-             (filename  like '/bbox%/physics_mvtx%.evt'  and lastevent>2 )
+             (filename  like '/bbox%/TPC%physics%.evt'   and lastevent>2 and transferred_to_sdcc ) or
+             (filename  like '/bbox%/TPOT%physics%.evt'  and lastevent>2 and transferred_to_sdcc ) or
+             (filename  like '/bbox%/physics_intt%.evt'  and lastevent>2 and transferred_to_sdcc ) or
+             (filename  like '/bbox%/GL1_physics%.evt'   and lastevent>2 and transferred_to_sdcc ) or
+             (filename  like '/bbox%/physics_mvtx%.evt'  and lastevent>2 and transferred_to_sdcc )
            )
 
          and runnumber>=run2pp.firstrun and runnumber<=run2pp.lastrun


### PR DESCRIPTION
For fixed build production ana441_2024p007 we want to produce all runs that have _any_ files transferred to sdcc.   By selecting only files which have been transferred, we will automatically satisfy the every file requirement in the having block.