### PR TITLE
Laser Event Rejection

### DIFF
--- a/run2auau/TrackingProduction/Fun4All_Job0.C
+++ b/run2auau/TrackingProduction/Fun4All_Job0.C
@@ -88,15 +88,16 @@ void Fun4All_Job0(
 
   Intt_Clustering();
 
+  Tpc_LaserEventIdentifying();
+
+  TPC_LaserClustering();
+
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(0);
   tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);
   tpcclusterizer->set_rawdata_reco();
+  tpcclusterizer->set_reject_event(G4TPC::REJECT_LASER_EVENTS);
   se->registerSubsystem(tpcclusterizer);
-
-  Tpc_LaserEventIdentifying();
-
-  TPC_LaserClustering();
 
   Micromegas_Clustering();
 

--- a/run2auau/TrackingProduction/Fun4All_JobA.C
+++ b/run2auau/TrackingProduction/Fun4All_JobA.C
@@ -86,6 +86,9 @@ void Fun4All_JobA(
 
   TrackingInit();
 
+  // reject laser events if G4TPC::REJECT_LASER_EVENTS is true
+  Reject_Laser_Events();
+
 /*
    * Silicon Seeding
    */

--- a/run2auau/TrackingProduction/Fun4All_JobC.C
+++ b/run2auau/TrackingProduction/Fun4All_JobC.C
@@ -76,6 +76,8 @@ void Fun4All_JobC(
 
   TrackingInit();
 
+  // reject laser events if G4TPC::REJECT_LASER_EVENTS is true 
+  Reject_Laser_Events();
 
   auto deltazcorr = new PHTpcDeltaZCorrection;
   deltazcorr->Verbosity(0);

--- a/run2pp/TrackingProduction/Fun4All_Job0.C
+++ b/run2pp/TrackingProduction/Fun4All_Job0.C
@@ -88,15 +88,16 @@ void Fun4All_Job0(
 
   Intt_Clustering();
 
+  Tpc_LaserEventIdentifying();
+
+  TPC_LaserClustering();
+
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(0);
   tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);
   tpcclusterizer->set_rawdata_reco();
+  tpcclusterizer->set_reject_event(G4TPC::REJECT_LASER_EVENTS);
   se->registerSubsystem(tpcclusterizer);
-
-  Tpc_LaserEventIdentifying();
-
-  TPC_LaserClustering();
 
   Micromegas_Clustering();
 

--- a/run2pp/TrackingProduction/Fun4All_JobA.C
+++ b/run2pp/TrackingProduction/Fun4All_JobA.C
@@ -83,6 +83,9 @@ void Fun4All_JobA(
   se->registerInputManager(ingeo);
 
   TrackingInit();
+  
+  // reject laser events if G4TPC::REJECT_LASER_EVENTS is true
+  Reject_Laser_Events();
 
 /*
    * Silicon Seeding

--- a/run2pp/TrackingProduction/Fun4All_JobC.C
+++ b/run2pp/TrackingProduction/Fun4All_JobC.C
@@ -76,6 +76,8 @@ void Fun4All_JobC(
 
   TrackingInit();
 
+  // reject laser events if G4TPC::REJECT_LASER_EVENTS is true 
+  Reject_Laser_Events();
 
   auto deltazcorr = new PHTpcDeltaZCorrection;
   deltazcorr->Verbosity(0);


### PR DESCRIPTION
Updated laser event rejection using a new module, exact same changes made for run2pp and run2auau tracking. Global flag (G4TPC::REJECT_LASER_EVENTS) in macros turns on/off the rejection everywhere (default is on)

In job 0, laser event identification and laser clustering must be done before tpc clustering. Tpc clustering will also return EVENT_OK if flag is true. In jobs A and C, new rejection module is called by new function in Trkr_Reco.C only if flag is true, and will return ABORTEVENT, skipping all further reconstruction for that event.

Requires https://github.com/sPHENIX-Collaboration/coresoftware/pull/3204 and https://github.com/sPHENIX-Collaboration/macros/pull