### PR TITLE
feat: mvtx bco range automatically set

### DIFF
--- a/run2auau/cosmics/Fun4All_SingleStream_Combiner.C
+++ b/run2auau/cosmics/Fun4All_SingleStream_Combiner.C
@@ -121,8 +121,6 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       readoutNumber = "MVTX"+felix;
       SingleMvtxPoolInput *mvtx_sngl = new SingleMvtxPoolInput("MVTX_" + to_string(i));
 //    mvtx_sngl->Verbosity(5);
-      mvtx_sngl->SetBcoRange(100);
-      mvtx_sngl->SetNegativeBco(100);
     
       mvtx_sngl->setHitContainerName("MVTXRAWHIT_" + felix);
       mvtx_sngl->setRawEventHeaderName("MVTXRAWEVTHEADER_" + felix);

--- a/run2auau/cosmics/Fun4All_Stream_Combiner.C
+++ b/run2auau/cosmics/Fun4All_Stream_Combiner.C
@@ -176,8 +176,6 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
     {
     SingleMvtxPoolInput *mvtx_sngl = new SingleMvtxPoolInput("MVTX_" + to_string(i));
     //    mvtx_sngl->Verbosity(3);
-    mvtx_sngl->SetBcoRange(100);
-    mvtx_sngl->SetNegativeBco(100);
     mvtx_sngl->AddListFile(iter);
     in->registerStreamingInput(mvtx_sngl, InputManagerType::MVTX);
     i++;

--- a/run2pp/cosmics/Fun4All_SingleStream_Combiner.C
+++ b/run2pp/cosmics/Fun4All_SingleStream_Combiner.C
@@ -121,8 +121,6 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       readoutNumber = "MVTX"+felix;
       SingleMvtxPoolInput *mvtx_sngl = new SingleMvtxPoolInput("MVTX_" + to_string(i));
 //    mvtx_sngl->Verbosity(5);
-      mvtx_sngl->SetBcoRange(100);
-      mvtx_sngl->SetNegativeBco(500);
     
       mvtx_sngl->setHitContainerName("MVTXRAWHIT_" + felix);
       mvtx_sngl->setRawEventHeaderName("MVTXRAWEVTHEADER_" + felix);

--- a/run2pp/cosmics/Fun4All_Stream_Combiner.C
+++ b/run2pp/cosmics/Fun4All_Stream_Combiner.C
@@ -176,8 +176,6 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
     {
     SingleMvtxPoolInput *mvtx_sngl = new SingleMvtxPoolInput("MVTX_" + to_string(i));
     //    mvtx_sngl->Verbosity(3);
-    mvtx_sngl->SetBcoRange(100);
-    mvtx_sngl->SetNegativeBco(500);
     mvtx_sngl->AddListFile(iter);
     in->registerStreamingInput(mvtx_sngl, InputManagerType::MVTX);
     i++;


### PR DESCRIPTION
The MVTX BCO range is now automatically set based on the strobe width extracted from the daqdb
https://github.com/sPHENIX-Collaboration/coresoftware/pull/3211