### PR TITLE
Lamination Fitting

### DIFF
--- a/run2auau/TrackingProduction/Fun4All_Job0.C
+++ b/run2auau/TrackingProduction/Fun4All_Job0.C
@@ -92,6 +92,10 @@ void Fun4All_Job0(
 
   TPC_LaserClustering();
 
+  G4TPC::LaminationOutputName = "Laminations_" + outfilename;
+
+  TPC_LaminationFitting();
+
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(0);
   tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);

--- a/run2auau/TrackingProduction/run_job0.sh
+++ b/run2auau/TrackingProduction/run_job0.sh
@@ -85,6 +85,8 @@ ls -la
 
 ./stageout.sh ${logbase}.root ${outdir}
 
+./stageout.sh Laminations_${logbase}.root ${outdir}
+
 for hfile in `ls HIST_*.root`; do
     echo Stageout ${hfile} to ${histdir}
     ./stageout.sh ${hfile} ${histdir}

--- a/run2pp/TrackingProduction/Fun4All_Job0.C
+++ b/run2pp/TrackingProduction/Fun4All_Job0.C
@@ -63,7 +63,7 @@ void Fun4All_Job0(
   while(std::getline(ifs,filepath))
     {
       if(i==0)
-	{
+      {
 	   std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(filepath);
 	   int runNumber = runseg.first;
 	   int segment = runseg.second;
@@ -92,6 +92,12 @@ void Fun4All_Job0(
 
   TPC_LaserClustering();
 
+  std::cout << "outfilename: " << outfilename << std::endl;
+  G4TPC::LaminationOutputName = "Laminations_" + outfilename;
+  std::cout << "lamination name: " << G4TPC::LaminationOutputName << std::endl;
+
+  TPC_LaminationFitting();
+
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(0);
   tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);
@@ -117,6 +123,7 @@ void Fun4All_Job0(
   if(G4TPC::ENABLE_CENTRAL_MEMBRANE_CLUSTERING)
   {
     out->AddNode("LASER_CLUSTER");
+    out->AddNode("LAMINATION_CLUSTER");
   }
   se->registerOutputManager(out);
 

--- a/run2pp/TrackingProduction/Fun4All_Job0.C
+++ b/run2pp/TrackingProduction/Fun4All_Job0.C
@@ -92,9 +92,7 @@ void Fun4All_Job0(
 
   TPC_LaserClustering();
 
-  std::cout << "outfilename: " << outfilename << std::endl;
   G4TPC::LaminationOutputName = "Laminations_" + outfilename;
-  std::cout << "lamination name: " << G4TPC::LaminationOutputName << std::endl;
 
   TPC_LaminationFitting();
 

--- a/run2pp/TrackingProduction/run_job0.sh
+++ b/run2pp/TrackingProduction/run_job0.sh
@@ -93,6 +93,8 @@ ls -la
 
 ./stageout.sh ${logbase}.root ${outdir}
 
+./stageout.sh Laminations_${logbase}.root ${outdir}
+
 for hfile in `ls HIST_*.root`; do
     echo Stageout ${hfile} to ${histdir}
     ./stageout.sh ${hfile} ${histdir}


### PR DESCRIPTION
New calls to lamination fitting in job0 for both run2pp and run2auau. This will perform the lamination fitting and write the resulting histograms to a file with the same name as the DST with "Laminations_" prepended. These files will be inputs in later jobs for the distortion corrections.

This PR requires changes made in coresoftware (https://github.com/sPHENIX-Collaboration/coresoftware/pull/3301) and macros (https://github.com/sPHENIX-Collaboration/macros/pull/1023)