### PR TITLE
Update workflows for alma9

### DIFF
--- a/run2auau/DST_CALIBRATIONS_run2auau.yaml
+++ b/run2auau/DST_CALIBRATIONS_run2auau.yaml
@@ -55,7 +55,6 @@ DST_MBD_CALIBRATION_run2auau:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {pass0dir} {PWD} {rsync}"
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"

--- a/run2auau/DST_STREAMING_EVENT_run2auau_new_2024p007.yaml
+++ b/run2auau/DST_STREAMING_EVENT_run2auau_new_2024p007.yaml
@@ -97,7 +97,6 @@ DST_STREAMING_EVENT_run2auau_new_2024p007:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run_cosmics.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) $(neventsper) {logdir} {comment} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -150,7 +149,6 @@ DST_TRKR_HIT_run2auau_new_2024p007:
 
 
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -206,7 +204,6 @@ DST_TRKR_CLUSTER_run2auau_new_2024p007:
               ;              
 
    job:
-     executable            : "{payload}/run_job0.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -260,7 +257,6 @@ DST_TRKR_SEED_run2auau_new_2024p007:
               ;              
 
    job:
-     executable            : "{payload}/run_jobA.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -327,7 +323,6 @@ DST_TRKR_TRACKS_run2auau_new_2024p007:
          ;
 
    job:
-     executable            : "{payload}/run_jobC.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2auau/DST_TRIGGERED_EVENT_run2auau_new_2024p007.yaml
+++ b/run2auau/DST_TRIGGERED_EVENT_run2auau_new_2024p007.yaml
@@ -200,7 +200,7 @@ DST_TRIGGERED_EVENT_run2auau_new_2024p007:
    # definition of the payload script.
    #
    job:
-     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
+     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event) {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"
@@ -249,7 +249,7 @@ DST_CALOFITTING_run2auau_new_2024p007:
 
          ;
    job:
-     arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
+     arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"

--- a/run2auau/DST_TRIGGERED_EVENT_run2auau_new_2024p007.yaml
+++ b/run2auau/DST_TRIGGERED_EVENT_run2auau_new_2024p007.yaml
@@ -200,7 +200,6 @@ DST_TRIGGERED_EVENT_run2auau_new_2024p007:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -250,7 +249,6 @@ DST_CALOFITTING_run2auau_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runy2fitting.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -296,7 +294,6 @@ DST_CALO_run2auau_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runy2calib.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -340,7 +337,6 @@ DST_JETS_run2auau_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runjets.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2auau/DST_TRIGGERED_EVENT_run2auau_vernierscan_new_2024p007.yaml
+++ b/run2auau/DST_TRIGGERED_EVENT_run2auau_vernierscan_new_2024p007.yaml
@@ -200,7 +200,7 @@ DST_TRIGGERED_EVENT_run2auau_new_2024p007:
    # definition of the payload script.
    #
    job:
-     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
+     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event) {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"

--- a/run2auau/DST_TRIGGERED_EVENT_run2auau_vernierscan_new_2024p007.yaml
+++ b/run2auau/DST_TRIGGERED_EVENT_run2auau_vernierscan_new_2024p007.yaml
@@ -200,7 +200,6 @@ DST_TRIGGERED_EVENT_run2auau_new_2024p007:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/runvs.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -250,7 +249,6 @@ DST_CALOFITTING_run2auau_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runy2fitting.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -297,7 +295,6 @@ DST_CALO_run2auau_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runy2calib.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -342,7 +339,6 @@ DST_JETS_run2auau_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runjets.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2auau/JetProduction/runjets.sh
+++ b/run2auau/JetProduction/runjets.sh
@@ -16,7 +16,6 @@ histdir=${13:-.}
 subdir=${14}
 payload=(`echo ${15} | tr ","  " "`) # array of files to be rsynced
 #--
-#export cupsid=${16}
 export cupsid=${@: -1}
 
 sighandler()

--- a/run2auau/TriggerProduction/run.sh
+++ b/run2auau/TriggerProduction/run.sh
@@ -18,8 +18,10 @@ payload=(`echo ${15} | tr ","  " "`) # array of files to be rsynced
 firstevent=${16}
 lastevent=${17}
 lasteventinrun=${18}
-#-- Must always be last + 1
-export cupsid=${19}
+
+# Cupsid will be appended at the end
+export cupsid=${@: -1}
+echo cupsid = $cupsid
 
 sighandler()
 {

--- a/run2auau/TriggerProduction/runvs.sh
+++ b/run2auau/TriggerProduction/runvs.sh
@@ -18,8 +18,10 @@ payload=(`echo ${15} | tr ","  " "`) # array of files to be rsynced
 firstevent=${16}
 lastevent=${17}
 lasteventinrun=${18}
-#-- Must always be last + 1
-export cupsid=${19}
+
+#-- Must always be last 
+export cupsid=${@: -1}
+
 
 sighandler()
 {

--- a/run2cosmics/DST_TRIGGERED_EVENT_run2cosmics_ana444_2024p007.yaml
+++ b/run2cosmics/DST_TRIGGERED_EVENT_run2cosmics_ana444_2024p007.yaml
@@ -196,7 +196,6 @@ DST_TRIGGERED_EVENT_run2cosmics_ana444_2024p007:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -246,7 +245,6 @@ DST_CALOFITTING_run2cosmics_ana444_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runhcalcosmics.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2cosmics/DST_TRIGGERED_EVENT_run2cosmics_ana444_2024p007.yaml
+++ b/run2cosmics/DST_TRIGGERED_EVENT_run2cosmics_ana444_2024p007.yaml
@@ -196,7 +196,7 @@ DST_TRIGGERED_EVENT_run2cosmics_ana444_2024p007:
    # definition of the payload script.
    #
    job:
-     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
+     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event) {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"

--- a/run2pp/DST_CALIBRATIONS_run2pp.yaml
+++ b/run2pp/DST_CALIBRATIONS_run2pp.yaml
@@ -58,7 +58,7 @@ DST_TPCCALIB_run2pp:
    # definition of the payload script.
    #
    job:
-     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir}"
+     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      transfer_input_files  : "{payload},cups.py,bachi.py,odbc.ini"
      log                   : '{condor}/{logbase}.condor'
@@ -125,7 +125,7 @@ DST_MBD_CALIBRATION_run2pp:
    # definition of the payload script.
    #
    job:
-     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {pass0dir}"
+     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {pass0dir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      transfer_input_files  : "{payload},cups.py,bachi.py,odbc.ini"
      log                   : '{condor}/{logbase}.condor'

--- a/run2pp/DST_CALIBRATIONS_run2pp.yaml
+++ b/run2pp/DST_CALIBRATIONS_run2pp.yaml
@@ -58,7 +58,6 @@ DST_TPCCALIB_run2pp:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run_cosmics.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir}"
      output_destination    : '{logdir}'
      transfer_input_files  : "{payload},cups.py,bachi.py,odbc.ini"
@@ -126,7 +125,6 @@ DST_MBD_CALIBRATION_run2pp:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {pass0dir}"
      output_destination    : '{logdir}'
      transfer_input_files  : "{payload},cups.py,bachi.py,odbc.ini"

--- a/run2pp/DST_STREAMING_EVENT_run2pp_ana439_2024p007.yaml
+++ b/run2pp/DST_STREAMING_EVENT_run2pp_ana439_2024p007.yaml
@@ -74,7 +74,6 @@ DST_STREAMING_EVENT_run2pp:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run_cosmics.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {comment} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -126,7 +125,6 @@ DST_TRKR_HIT_run2pp:
               ;              
 
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -182,7 +180,6 @@ DST_TRKR_CLUSTER_run2pp:
               ;              
 
    job:
-     executable            : "{payload}/run_job0.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -236,7 +233,6 @@ DST_TRKR_SEED_run2pp:
               ;              
 
    job:
-     executable            : "{payload}/run_jobA.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -303,7 +299,6 @@ DST_TRKR_TRACKS_run2pp:
          ;
 
    job:
-     executable            : "{payload}/run_jobC.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2pp/DST_STREAMING_EVENT_run2pp_ana441_2024p007.yaml
+++ b/run2pp/DST_STREAMING_EVENT_run2pp_ana441_2024p007.yaml
@@ -72,7 +72,6 @@ DST_STREAMING_EVENT_run2pp:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run_cosmics.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {comment} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -124,7 +123,6 @@ DST_TRKR_HIT_run2pp:
               ;              
 
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -179,7 +177,6 @@ DST_TRKR_CLUSTER_run2pp:
                 {limit_condition}
               ;              
    job:
-     executable            : "{payload}/run_job0.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -232,7 +229,6 @@ DST_TRKR_SEED_run2pp:
                 {limit_condition}
               ;              
    job:
-     executable            : "{payload}/run_jobA.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -300,7 +296,6 @@ DST_TRKR_TRACKS_run2pp:
               ;              
 
    job:
-     executable            : "{payload}/run_jobC.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2pp/DST_TRIGGERED_EVENT_run2pp_ana437_2024p007.yaml
+++ b/run2pp/DST_TRIGGERED_EVENT_run2pp_ana437_2024p007.yaml
@@ -198,7 +198,6 @@ DST_TRIGGERED_EVENT_run2pp_ana437_2024p007:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -245,7 +244,6 @@ DST_CALO_Y2_FITTING:
 
          ;
    job:
-     executable            : "{payload}/runy2fitting.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -291,7 +289,6 @@ DST_CALO_Y2_CALIB:
 
          ;
    job:
-     executable            : "{payload}/runy2calib.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -335,7 +332,6 @@ DST_CALO_Y2_JETS:
 
          ;
    job:
-     executable            : "{payload}/runjets.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2pp/DST_TRIGGERED_EVENT_run2pp_ana437_2024p007.yaml
+++ b/run2pp/DST_TRIGGERED_EVENT_run2pp_ana437_2024p007.yaml
@@ -198,7 +198,7 @@ DST_TRIGGERED_EVENT_run2pp_ana437_2024p007:
    # definition of the payload script.
    #
    job:
-     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
+     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event) {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"

--- a/run2pp/DST_TRIGGERED_EVENT_run2pp_ana444_2024p007.yaml
+++ b/run2pp/DST_TRIGGERED_EVENT_run2pp_ana444_2024p007.yaml
@@ -200,7 +200,7 @@ DST_TRIGGERED_EVENT_run2pp_ana444_2024p007:
    # definition of the payload script.
    #
    job:
-     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
+     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event) {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"

--- a/run2pp/DST_TRIGGERED_EVENT_run2pp_ana444_2024p007.yaml
+++ b/run2pp/DST_TRIGGERED_EVENT_run2pp_ana444_2024p007.yaml
@@ -200,7 +200,6 @@ DST_TRIGGERED_EVENT_run2pp_ana444_2024p007:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -250,7 +249,6 @@ DST_CALOFITTING_run2pp_ana444_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runy2fitting.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -294,7 +292,6 @@ DST_JETSKIMMED_run2pp_ana444_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runy2jetskim.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2pp/DST_TRIGGERED_EVENT_run2pp_new_2024p007.yaml
+++ b/run2pp/DST_TRIGGERED_EVENT_run2pp_new_2024p007.yaml
@@ -200,7 +200,7 @@ DST_TRIGGERED_EVENT_run2pp_new_2024p007:
    # definition of the payload script.
    #
    job:
-     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
+     arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event) {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
      accounting_group      : "group_sphenix.mdc2"

--- a/run2pp/DST_TRIGGERED_EVENT_run2pp_new_2024p007.yaml
+++ b/run2pp/DST_TRIGGERED_EVENT_run2pp_new_2024p007.yaml
@@ -200,7 +200,6 @@ DST_TRIGGERED_EVENT_run2pp_new_2024p007:
    # definition of the payload script.
    #
    job:
-     executable            : "{payload}/run.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync} $(firstevent) $(lastevent) $(runs_last_event)"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -250,7 +249,6 @@ DST_CALOFITTING_run2pp_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runy2fitting.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -295,7 +293,6 @@ DST_CALO_run2pp_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runy2calib.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -339,7 +336,6 @@ DST_JETS_run2pp_new_2024p007:
 
          ;
    job:
-     executable            : "{payload}/runjets.sh"
      arguments             : "$(nevents) {outbase} {logbase} $(run) $(seg) $(outdir) $(buildarg) $(tag) $(inputs) $(ranges) {neventsper} {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2pp/DST_TRKR_CLUSTERS_run2pp_ana449_2024p008.yaml
+++ b/run2pp/DST_TRKR_CLUSTERS_run2pp_ana449_2024p008.yaml
@@ -44,7 +44,6 @@ DST_TRKR_CLUSTER_run2pp:
 
 
    job:
-     executable            : "{payload}/run_job0.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'
@@ -99,7 +98,6 @@ DST_TRKR_SEED_run2pp:
 
 
    job:
-     executable            : "{payload}/run_jobA.sh"
      arguments             : "{nevents} {outbase} {logbase} $(run) $(seg) {outdir} $(buildarg) $(tag) $(inputs) $(ranges) {logdir} {histdir} {PWD} {rsync}"
      output_destination    : '{logdir}'
      log                   : '{condor}/{logbase}.condor'

--- a/run2pp/JetProduction/runjets.sh
+++ b/run2pp/JetProduction/runjets.sh
@@ -15,8 +15,8 @@ logdir=${12:-.}
 histdir=${13:-.}
 subdir=${14}
 payload=(`echo ${15} | tr ","  " "`) # array of files to be rsynced
+
 #--
-#export cupsid=${16}
 export cupsid=${@: -1}
 
 sighandler()

--- a/run2pp/TriggerProduction/run.sh
+++ b/run2pp/TriggerProduction/run.sh
@@ -18,8 +18,9 @@ payload=(`echo ${15} | tr ","  " "`) # array of files to be rsynced
 firstevent=${16}
 lastevent=${17}
 lasteventinrun=${18}
+
 #-- Must always be last + 1
-export cupsid=${19}
+export cupsid=${@: -1}
 
 sighandler()
 {


### PR DESCRIPTION
Alma 9 support in slurp uses a common job wrapper.  The system passes the name of the user's production 
script as the first argument, and appends the production status id (aka 'cupsid') as the last argument.  

It relies on being able to stage in the user's production script, which is part of the list of
files to be 'rsync'ed into the job.  This requires us to pass the directory from which we 
submitted the job (PWD) and the list of files (rsync) to be specified in the list of arguments
in the condor job block.

Ideally the system would manage this, but the place where we should append this information does not
have easy access to the PWD...  I need to spend some time to sort out why.  The easiest way to get this in production is to append these by hand in the workflow files. 

We don't make any reordering of the arguments... which means we duplicate PWD and rsync in the arguments of a few jobs.  But this is harmless.  The benefit is that we don't need to touch the production scripts. They still get the list of arguments in the order that they expect.  So in principle these workflows are ready to launch.