### PR TITLE
fix: use time frame reader

### DIFF
--- a/run2pp/streaming/Fun4All_Stream_Combiner.C
+++ b/run2pp/streaming/Fun4All_Stream_Combiner.C
@@ -10,7 +10,8 @@
 #include <fun4allraw/SingleInttPoolInput.h>
 #include <fun4allraw/SingleMicromegasPoolInput.h>
 #include <fun4allraw/SingleMvtxPoolInput.h>
-#include <fun4allraw/SingleTpcPoolInput.h>
+
+#include <fun4allraw/SingleTpcTimeFrameInput.h>
 
 #include <phool/recoConsts.h>
 
@@ -188,11 +189,10 @@ void Fun4All_Stream_Combiner(int nEvents = 100,
   {
     if (isGood(iter))
     {
-    SingleTpcPoolInput *tpc_sngl = new SingleTpcPoolInput("TPC_" + to_string(i));
+    SingleTpcTimeFrameInput *tpc_sngl = new SingleTpcTimeFrameInput("TPC_" + to_string(i));
 //    tpc_sngl->Verbosity(2);
     //   tpc_sngl->DryRun();
-    tpc_sngl->SetBcoRange(5);
-    tpc_sngl->SetMaxTpcTimeSamples(1024);
+    tpc_sngl->setHitContainerName("TPCRAWHIT");
     tpc_sngl->AddListFile(iter);
     in->registerStreamingInput(tpc_sngl, InputManagerType::TPC);
     i++;


### PR DESCRIPTION
Updates the combined combiner to use the time frame reader instead of the pooler