### PR TITLE
fix: add max seeds cut

### DIFF
--- a/run2pp/TrackingProduction/Fun4All_JobA.C
+++ b/run2pp/TrackingProduction/Fun4All_JobA.C
@@ -170,6 +170,7 @@ void Fun4All_JobA(
   }
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
+  cprop->set_max_seeds(5000);
   cprop->Verbosity(0);
   cprop->set_pp_mode(true);
   se->registerSubsystem(cprop);


### PR DESCRIPTION
This adds a cut in on the max number of seeds to avoid events where the seeder goes awry