### PR TITLE
fix: update vertexing in jobc

### DIFF
--- a/run2pp/TrackingProduction/Fun4All_JobA.C
+++ b/run2pp/TrackingProduction/Fun4All_JobA.C
@@ -187,6 +187,7 @@ void Fun4All_JobA(
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfilename);
   out->AddNode("Sync");
   out->AddNode("EventHeader");
+  out->AddNode("GL1RAWHIT");
   out->AddNode("SiliconTrackSeedContainer");
   out->AddNode("TpcTrackSeedContainer");
 

--- a/run2pp/TrackingProduction/Fun4All_JobC.C
+++ b/run2pp/TrackingProduction/Fun4All_JobC.C
@@ -101,9 +101,6 @@ void Fun4All_JobC(
    */
   G4TPC::REJECT_LASER_EVENTS=true;
   TRACKING::pp_mode = true;
-  ACTSGEOM::mvtxMisalignment = 100;
-  ACTSGEOM::inttMisalignment = 100.;
-  ACTSGEOM::tpotMisalignment = 100.;
   TrackingInit();
 
   // reject laser events if G4TPC::REJECT_LASER_EVENTS is true 

--- a/run2pp/TrackingProduction/Fun4All_JobC.C
+++ b/run2pp/TrackingProduction/Fun4All_JobC.C
@@ -187,7 +187,7 @@ void Fun4All_JobC(
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfilename);
   out->AddNode("Sync");
   out->AddNode("EventHeader");
-  
+  out->AddNode("GL1RAWHIT");
   out->AddNode("SvtxTrackSeedContainer");
   out->AddNode("SvtxTrackMap");
   out->AddNode("SvtxVertexMap");

--- a/run2pp/TrackingProduction/Fun4All_JobC.C
+++ b/run2pp/TrackingProduction/Fun4All_JobC.C
@@ -166,15 +166,21 @@ void Fun4All_JobC(
 
   PHSimpleVertexFinder *finder = new PHSimpleVertexFinder;
   finder->Verbosity(0);
-  finder->setDcaCut(0.5);
-  finder->setTrackPtCut(-99999.);
+  finder->setDcaCut(0.02);
+  finder->setTrackPtCut(0.1);
   finder->setBeamLineCut(1);
-  finder->setTrackQualityCut(1000000000);
+  finder->setTrackQualityCut(100);
   finder->setNmvtxRequired(3);
-  finder->setOutlierPairCut(0.1);
+  finder->setOutlierPairCut(0.05);
   se->registerSubsystem(finder);
 
-    auto tpcsiliconqa = new TpcSiliconQA;
+  auto vtxProp = new PHActsVertexPropagator;
+  vtxProp->Verbosity(0);
+  vtxProp->fieldMap(G4MAGNET::magfield_tracking);
+  se->registerSubsystem(vtxProp);
+  
+  
+  auto tpcsiliconqa = new TpcSiliconQA;
   se->registerSubsystem(tpcsiliconqa);
 
   

--- a/run2pp/TrackingProduction/Fun4All_SingleJob0.C
+++ b/run2pp/TrackingProduction/Fun4All_SingleJob0.C
@@ -166,6 +166,7 @@ void Fun4All_SingleJob0(
   out->AddNode("TRKR_CLUSTER");
   out->AddNode("TRKR_CLUSTERCROSSINGASSOC");
   out->AddNode("LaserEventInfo");
+  out->AddNode("GL1RAWHIT");
   if(G4TPC::ENABLE_CENTRAL_MEMBRANE_CLUSTERING)
   {
     out->AddNode("LAMINATION_CLUSTER");


### PR DESCRIPTION
This updates the jobC macro to use new improved vertexing cuts given the current state of the alignment and to also propagate the tracks back to the vertex position for much improved DCA resolution.

It also adds the GL1RAWHIT node to the output DST for all jobs, so that it is persistent and one can always access the trigger bit regardless of what DST they are looking at.

Also removes the misalignment factors, which tests show are no longer necessary