### PR TITLE
refactor: single bco qa file

### DIFF
--- a/run3auau/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run3auau/streaming/Fun4All_SingleStream_Combiner.C
@@ -219,15 +219,9 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 
   se->registerOutputManager(out);
 
-  auto hm = QAHistManagerDef::getHistoManager();
-  hm->SetClosingScript("stageout.sh");
-  hm->SetClosingScriptArgs(histdir);
-  hm->dumpHistoSegments(true);
   char histoutfile[500];
-  sprintf(histoutfile,"./HIST_%s",type.c_str());
-  string shistoutfile(histoutfile);
-  hm->setOutfileName(shistoutfile);
-  
+  sprintf(histoutfile,"./HIST_%s-%08i-%05i.root",type.c_str(),runnumber,0);
+  QAHistManagerDef::saveQARootFile(histoutfile);
   
   if (nEvents < 0)
   {


### PR DESCRIPTION
This returns the online macro to producing a single QA file, which will be easier in handling in the offline qa world