### PR TITLE
fix: streaming qa file production

### DIFF
--- a/run3auau/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run3auau/streaming/Fun4All_SingleStream_Combiner.C
@@ -219,10 +219,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 
   se->registerOutputManager(out);
 
-  char histoutfile[500];
-  sprintf(histoutfile,"./HIST_%s-%08i-%05i.root",type.c_str(),runnumber,0);
-  QAHistManagerDef::saveQARootFile(histoutfile);
-  
+
   if (nEvents < 0)
   {
     return;
@@ -231,6 +228,10 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 
   se->End();
 
+  char histoutfile[500];
+  sprintf(histoutfile,"./HIST_%s-%08i-%05i.root",type.c_str(),runnumber,0);
+  QAHistManagerDef::saveQARootFile(histoutfile);
+  
 
   delete se;
   cout << "all done" << endl;


### PR DESCRIPTION
This fixes the event combining qa to run after End is called, which inadvertently got moved when removing the segmentized histogramming