### PR TITLE
Update filename string replacement in runy2calib.sh

### DIFF
--- a/run3auau/CaloProduction/runy2calib.sh
+++ b/run3auau/CaloProduction/runy2calib.sh
@@ -100,8 +100,8 @@ for infile_ in ${inputs[@]}; do
 
     infile=$infile_
     
-    outfile=${infile/CALOFITTING/CALO}
-    outhist=${outfile/DST_CALO/HIST_CALOQA}
+    outfile=${infile//CALOFITTING/CALO}
+    outhist=${outfile//DST_CALO/HIST_CALOQA}
     root.exe -q -b Fun4All_Year2_Calib.C\(${nevents},\"${infile}\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\);  status_f4a=$?
 
     # Stageout the (single) DST created in the macro run


### PR DESCRIPTION
The input name right now for the online production is a absolute path(for example: /sphenix/lustre01/sphnxpro/production/run3auau/cosmics/new_2025p000_v000/DST_CALOFITTING/run_00061900_00062000/dst/DST_CALOFITTING_run3auau_new_2025p000_v000-00061985-00290.root)

only replace the first instance of the string won't change the file name properly. This PR replaces all