### PR TITLE
Laser QA and fixes

### DIFF
--- a/run2auau/TrackingProduction/Fun4All_SingleJob0.C
+++ b/run2auau/TrackingProduction/Fun4All_SingleJob0.C
@@ -63,7 +63,7 @@ void Fun4All_SingleJob0(
   std::string filepath;
 
   TRACKING::tpc_zero_supp = true;
-  G4TPC::ENABLE_CENTRAL_MEMBRANE_CLUSTERING = false;  
+  G4TPC::ENABLE_CENTRAL_MEMBRANE_CLUSTERING = true;  
   
   int i = 0;
   

--- a/run2auau/TrackingProduction/Fun4All_SingleJob0.C
+++ b/run2auau/TrackingProduction/Fun4All_SingleJob0.C
@@ -168,6 +168,7 @@ void Fun4All_SingleJob0(
   if(G4TPC::ENABLE_CENTRAL_MEMBRANE_CLUSTERING)
   {
     out->AddNode("LASER_CLUSTER");
+    out->AddNode("LAMINATION_CLUSTER");
   }
   se->registerOutputManager(out);
 

--- a/run2pp/TrackingProduction/Fun4All_SingleJob0.C
+++ b/run2pp/TrackingProduction/Fun4All_SingleJob0.C
@@ -135,7 +135,9 @@ void Fun4All_SingleJob0(
   Tpc_LaserEventIdentifying();
   
   TPC_LaminationClustering();
-  
+
+  TPC_LaserClustering();
+
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(0);
   tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);
@@ -169,6 +171,7 @@ void Fun4All_SingleJob0(
   out->AddNode("GL1RAWHIT");
   if(G4TPC::ENABLE_CENTRAL_MEMBRANE_CLUSTERING)
   {
+    out->AddNode("LASER_CLUSTER");
     out->AddNode("LAMINATION_CLUSTER");
   }
   se->registerOutputManager(out);

--- a/run3auau/TrackingProduction/Fun4All_Job0.C
+++ b/run3auau/TrackingProduction/Fun4All_Job0.C
@@ -20,6 +20,7 @@
 #include <ffamodules/FlagHandler.h>
 #include <ffamodules/CDBInterface.h>
 
+#include <tpcqa/TpcLaserQA.h>
 #include <trackingqa/InttClusterQA.h>
 #include <trackingqa/MicromegasClusterQA.h>
 #include <trackingqa/MvtxClusterQA.h>
@@ -107,7 +108,7 @@ void Fun4All_Job0(
   se->registerSubsystem(new InttClusterQA);
   se->registerSubsystem(new TpcClusterQA);
   se->registerSubsystem(new MicromegasClusterQA);
-
+  se->registerSubsystem(new TpcLaserQA);
 
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfilename);
   //out->StripNode("TRKR_HITSET");

--- a/run3auau/TrackingProduction/Fun4All_SingleJob0.C
+++ b/run3auau/TrackingProduction/Fun4All_SingleJob0.C
@@ -28,6 +28,7 @@
 #include <mvtxrawhitqa/MvtxRawHitQA.h>
 #include <inttrawhitqa/InttRawHitQA.h>
 #include <tpcqa/TpcRawHitQA.h>
+#include <tpcqa/TpcLaserQA.h>
 #include <phool/recoConsts.h>
 
 #include <stdio.h>
@@ -162,6 +163,9 @@ void Fun4All_SingleJob0(
   auto tpc = new TpcRawHitQA;
   se->registerSubsystem(tpc);
 
+  auto LaserQA = new TpcLaserQA;
+  se->registerSubsystem(LaserQA);
+  
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfilename);
   out->AddNode("Sync");
   out->AddNode("EventHeader");
@@ -172,6 +176,7 @@ void Fun4All_SingleJob0(
   if(G4TPC::ENABLE_CENTRAL_MEMBRANE_CLUSTERING)
   {
     out->AddNode("LASER_CLUSTER");
+    out->AddNode("LAMINATION_CLUSTER");
   }
   se->registerOutputManager(out);
 


### PR DESCRIPTION
Adds laser QA to production for run3auau. Also fixes some issues with run2pp and run2auau where in some cases laser clusters were not generated not written to DST, likewise for lamination clusters