### PR TITLE
apply 1k downscale to event wise printouts

### DIFF
--- a/run2auau/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run2auau/streaming/Fun4All_SingleStream_Combiner.C
@@ -68,6 +68,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(1);
+  se->VerbosityDownscale(1000); // only print every 1000th event
   recoConsts *rc = recoConsts::instance();
   CDBInterface::instance()->Verbosity(1);
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag );

--- a/run2pp/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run2pp/streaming/Fun4All_SingleStream_Combiner.C
@@ -68,6 +68,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(1);
+  se->VerbosityDownscale(1000); // only print every 1000th event
   recoConsts *rc = recoConsts::instance();
   CDBInterface::instance()->Verbosity(1);
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag );

--- a/run3auau/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run3auau/streaming/Fun4All_SingleStream_Combiner.C
@@ -68,6 +68,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 
   Fun4AllServer *se = Fun4AllServer::instance();
 //  se->Verbosity(1);
+//  se->VerbosityDownscale(1000); // only print every 1000th event
   recoConsts *rc = recoConsts::instance();
   CDBInterface::instance()->Verbosity(1);
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag );


### PR DESCRIPTION
This applies a downscale of 1000 to the event wise printouts in the Fun4All_SingleStream_Combiner.C macros. Feel free to use this in other macros