### PR TITLE
fix: add runnumber flag

### DIFF
--- a/run3auau/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run3auau/streaming/Fun4All_SingleStream_Combiner.C
@@ -72,6 +72,8 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
   recoConsts *rc = recoConsts::instance();
   CDBInterface::instance()->Verbosity(1);
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag );
+  
+  rc->set_IntFlag("RUNNUMBER", runnumber);
   Fun4AllStreamingInputManager *in = new Fun4AllStreamingInputManager("Comb");
 //  in->Verbosity(3);
 


### PR DESCRIPTION
Adds the runnumber flag to the streaming macro for the INTT bco range lookup