### PR TITLE
Propagate upstream changes for year 3 jet production

### DIFF
--- a/run2auau/JetProduction/Fun4All_CaloJetProductionYear2.C
+++ b/run2auau/JetProduction/Fun4All_CaloJetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run2auau/JetProduction/Fun4All_CaloJetProductionYear2.C
+++ b/run2auau/JetProduction/Fun4All_CaloJetProductionYear2.C
@@ -1,5 +1,6 @@
-#ifndef FUN4ALL_JETPRODUCTIONYEAR3_C
-#define FUN4ALL_JETPRODUCTIONYEAR3_C
+#ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_C
+#define FUN4ALL_CALOJETPRODUCTIONYEAR2_C
+
 
 // c++ utilities
 #include <fstream>
@@ -32,7 +33,8 @@
 #include <G4_Global.C>
 #include <G4_Magnet.C>
 #include <GlobalVariables.C>
-#include <HIJetReco.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
 #include <Jet_QA.C>
 #include <QA.C>
 #include <Trkr_Reco.C>
@@ -54,32 +56,20 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 // ============================================================================
-//! Jet production macro for year 3 (AuAu)
+//! Calorimeter jet production macro for year 2 (pp)
 // ============================================================================
-/*! Jet production macro for AuAu-running in year 3. Currently used for
+/*! Jet production macro for pp-running in year 2. Currently used for
  *  producing for QA. Can be adapted for production of JET DSTs in the
  *  future.
  *
- *  Necessary inputs:
- *    - For calo jets:
- *      - DST_CALO
- *    - For track jets:
- *      - DST_CALO (for beam background filter)
- *      - DST_TRKR_TRACKS
- *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ *  Necessary inputs for calo jets:
+ *    - DST_CALO
  */
-void Fun4All_JetProductionYear3(
+void Fun4All_CaloJetProductionYear2(
   const int nEvents = 0,
-  const bool useTwrs = true,
-  const bool useTrks = false,
-  const bool useFlow = false,
-  const std::vector<std::string>& inlists = {
-    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
-  },
+  const std::string& inlist = "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
   const std::string& outfile = "DST_JET-00053877-0000.root",
-  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year3_tracktest.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
   const std::string& dbtag = "ProdA_2024"
 ) {
 
@@ -88,33 +78,39 @@ void Fun4All_JetProductionYear3(
   // turn on/off DST output and/or QA
   Enable::DSTOUT           = false;
   Enable::QA               = true;
-  Enable::HIJETS_VERBOSITY = 0;
-  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::HIJETS_VERBOSITY);
+  Enable::NSJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
 
   // jet reco options
-  Enable::HIJETS         = true;
-  Enable::HIJETS_TOWER   = useTwrs;
-  Enable::HIJETS_TRACK   = useTrks;
-  Enable::HIJETS_PFLOW   = useFlow;
-  HIJETS::is_pp          = false;
-  HIJETS::do_vertex_type = true;
-  HIJETS::vertex_type    = Enable::HIJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+  Enable::NSJETS         = true;
+  Enable::NSJETS_TOWER   = true;
+  Enable::NSJETS_TRACK   = false;
+  Enable::NSJETS_PFLOW   = false;
+  NSJETS::is_pp          = true;
+  NSJETS::do_vertex_type = true;
+  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // make sure HIJetReco inputs are the same
+  // for rho calculation
+  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
+  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
+  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
 
   // qa options
   JetQA::DoInclusive      = true;
   JetQA::DoTriggered      = true;
-  JetQA::DoPP             = HIJETS::is_pp;
-  JetQA::UseBkgdSub       = true;
+  JetQA::DoPP             = NSJETS::is_pp;
+  JetQA::UseBkgdSub       = false;
   JetQA::RestrictPtToTrig = false;
   JetQA::RestrictEtaByR   = true;
-  JetQA::HasTracks        = Enable::HIJETS_TRACK || Enable::HIJETS_PFLOW;
-  JetQA::HasCalos         = Enable::HIJETS_TOWER || Enable::HIJETS_PFLOW;
+  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
+  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
 
   // tracking options
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = HIJETS::is_pp;
+  TRACKING::pp_mode                     = NSJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 
@@ -123,7 +119,7 @@ void Fun4All_JetProductionYear3(
   se -> Verbosity(1);
 
   // grab 1st file from input lists
-  ifstream    files(inlists.front());
+  ifstream    files(inlist);
   std::string first("");
   std::getline(files, first);
 
@@ -145,12 +141,9 @@ void Fun4All_JetProductionYear3(
   se -> registerSubsystem(flag);
 
   // read in input
-  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
-  {
-    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
-    indst -> AddListFile(inlists[iin]);
-    se -> registerInputManager(indst);
-  }
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
 
   // set up tracking
   if (JetQA::HasTracks)
@@ -169,7 +162,7 @@ void Fun4All_JetProductionYear3(
 
   // do vertex & centrality reconstruction
   Global_Reco();
-  if (!HIJETS::is_pp)
+  if (!NSJETS::is_pp)
   {
     Centrality();
   }
@@ -189,7 +182,7 @@ void Fun4All_JetProductionYear3(
   se -> registerSubsystem(filter);
 
   // do jet reconstruction
-  HIJetReco();  
+  NoBkgdSubJetReco();
 
   // register modules necessary for QA
   if (Enable::QA)

--- a/run2auau/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
+++ b/run2auau/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run2auau/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
+++ b/run2auau/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
@@ -1,5 +1,6 @@
-#ifndef FUN4ALL_JETPRODUCTIONYEAR2_AUAU_C
-#define FUN4ALL_JETPRODUCTIONYEAR2_AUAU_C
+#ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
+#define FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
+
 
 // c++ utilities
 #include <fstream>
@@ -54,30 +55,18 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 // ============================================================================
-//! Jet production macro for year 2 (AuAu)
+//! Calorimeter jet production macro for year 2 (AuAu)
 // ============================================================================
 /*! Jet production macro for AuAu-running in year 2. Currently used for
  *  producing for QA. Can be adapted for production of JET DSTs in the
  *  future.
  *
- *  Necessary inputs:
- *    - For calo jets:
- *      - DST_CALO
- *    - For track jets:
- *      - DST_CALO (for beam background filter)
- *      - DST_TRKR_TRACKS
- *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ *  Necessary inputs for calo jets:
+ *    - DST_CALO
  */
-void Fun4All_JetProductionYear2_AuAu(
+void Fun4All_CaloJetProductionYear2_AuAu(
   const int nEvents = 0,
-  const bool useTwrs = true,
-  const bool useTrks = false,
-  const bool useFlow = false,
-  const std::vector<std::string>& inlists = {
-    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
-  },
+  const std::string& inlist =  "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
   const std::string& outfile = "DST_JET-00053877-0000.root",
   const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2aa_tracktest.root",
   const std::string& dbtag = "ProdA_2024"
@@ -93,9 +82,9 @@ void Fun4All_JetProductionYear2_AuAu(
 
   // jet reco options
   Enable::HIJETS         = true;
-  Enable::HIJETS_TOWER   = useTwrs;
-  Enable::HIJETS_TRACK   = useTrks;
-  Enable::HIJETS_PFLOW   = useFlow;
+  Enable::HIJETS_TOWER   = true;
+  Enable::HIJETS_TRACK   = false;
+  Enable::HIJETS_PFLOW   = false;
   HIJETS::is_pp          = false;
   HIJETS::do_vertex_type = true;
   HIJETS::vertex_type    = Enable::HIJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
@@ -123,7 +112,7 @@ void Fun4All_JetProductionYear2_AuAu(
   se -> Verbosity(1);
 
   // grab 1st file from input lists
-  ifstream    files(inlists.front());
+  ifstream    files(inlist);
   std::string first("");
   std::getline(files, first);
 
@@ -145,12 +134,9 @@ void Fun4All_JetProductionYear2_AuAu(
   se -> registerSubsystem(flag);
 
   // read in input
-  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
-  {
-    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
-    indst -> AddListFile(inlists[iin]);
-    se -> registerInputManager(indst);
-  }
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
 
   // set up tracking
   if (JetQA::HasTracks)

--- a/run2auau/JetProduction/Fun4All_JetProductionYear2_AuAu.C
+++ b/run2auau/JetProduction/Fun4All_JetProductionYear2_AuAu.C
@@ -20,8 +20,7 @@
 #include <fun4all/Fun4AllUtils.h>
 #include <g4centrality/PHG4CentralityReco.h>
 #include <globalvertex/GlobalVertexReco.h>
-#include <jetbackground/DetermineTowerRho.h>
-#include <jetbackground/TowerRho.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
 #include <mbd/MbdReco.h>
 #include <phool/recoConsts.h>
 #include <qautils/QAHistManagerDef.h>
@@ -36,6 +35,9 @@
 #include <HIJetReco.C>
 #include <Jet_QA.C>
 #include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)
@@ -51,36 +53,77 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 
-// macro body -----------------------------------------------------------------
-
+// ============================================================================
+//! Jet production macro for year 2 (AuAu)
+// ============================================================================
+/*! Jet production macro for AuAu-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary inputs:
+ *    - For calo jets:
+ *      - DST_CALO
+ *    - For track jets:
+ *      - DST_CALO (for beam background filter)
+ *      - DST_TRKR_TRACKS
+ *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ */
 void Fun4All_JetProductionYear2_AuAu(
   const int nEvents = 0,
-  const std::string& inlist = "TestListInput.list",
-  const std::string& outfile = "DST_JET-00042586-0000.root",
-  const std::string& outfile_hist = "HIST_JETQA-00042586-0000.root",
+  const bool useTwrs = true,
+  const bool useTrks = false,
+  const bool useFlow = false,
+  const std::vector<std::string>& inlists = {
+    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
+  },
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2aa_tracktest.root",
   const std::string& dbtag = "ProdA_2024"
 ) {
 
-  // turn on/off DST output and/or QA
-  Enable::DSTOUT = false;
-  Enable::QA = true;
+  // set options --------------------------------------------------------------
 
-  // turn on pp mode
-  HIJETS::is_pp = false;
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::HIJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::HIJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::HIJETS         = true;
+  Enable::HIJETS_TOWER   = useTwrs;
+  Enable::HIJETS_TRACK   = useTrks;
+  Enable::HIJETS_PFLOW   = useFlow;
+  HIJETS::is_pp          = false;
+  HIJETS::do_vertex_type = true;
+  HIJETS::vertex_type    = Enable::HIJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
 
   // qa options
-  JetQA::HasTracks = false;
-  JetQA::DoInclusive = true;
-  JetQA::DoTriggered = true;
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = HIJETS::is_pp;
+  JetQA::UseBkgdSub       = true;
   JetQA::RestrictPtToTrig = false;
-  JetQA::RestrictEtaByR = true;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::HIJETS_TRACK || Enable::HIJETS_PFLOW;
+  JetQA::HasCalos         = Enable::HIJETS_TOWER || Enable::HIJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = HIJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
 
   // initialize F4A server
   Fun4AllServer* se = Fun4AllServer::instance();
   se -> Verbosity(1);
 
-  // grab 1st file from input list
-  ifstream    files(inlist);
+  // grab 1st file from input lists
+  ifstream    files(inlists.front());
   std::string first("");
   std::getline(files, first);
 
@@ -94,16 +137,35 @@ void Fun4All_JetProductionYear2_AuAu(
   rc -> set_uint64Flag("TIMESTAMP", runnumber);
 
   // connect to conditions database
-  CDBInterface::instance()->Verbosity(1);
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
 
   // set up flag handler
   FlagHandler* flag = new FlagHandler();
   se -> registerSubsystem(flag);
 
   // read in input
-  Fun4AllInputManager* in = new Fun4AllDstInputManager("in");
-  in -> AddListFile(inlist);
-  se -> registerInputManager(in);
+  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
+  {
+    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
+    indst -> AddListFile(inlists[iin]);
+    se -> registerInputManager(indst);
+  }
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
 
   // do vertex & centrality reconstruction
   Global_Reco();
@@ -112,7 +174,21 @@ void Fun4All_JetProductionYear2_AuAu(
     Centrality();
   }
 
-  // do jet reconstruction & rho calculation
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
   HIJetReco();  
 
   // register modules necessary for QA
@@ -134,6 +210,8 @@ void Fun4All_JetProductionYear2_AuAu(
     se -> registerOutputManager(out);
   }
 
+  // run & exit ---------------------------------------------------------------
+
   // run4all
   se -> run(nEvents);
   se -> End();
@@ -145,7 +223,7 @@ void Fun4All_JetProductionYear2_AuAu(
   }
 
   // print used DB files, time elapsed and delete server
-  CDBInterface::instance() -> Print();
+  cdb -> Print();
   se -> PrintTimer();
   delete se;
 

--- a/run2auau/JetProduction/Fun4All_TrackJetProductionYear2.C
+++ b/run2auau/JetProduction/Fun4All_TrackJetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run2auau/JetProduction/Fun4All_TrackJetProductionYear2.C
+++ b/run2auau/JetProduction/Fun4All_TrackJetProductionYear2.C
@@ -1,0 +1,233 @@
+#ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
+#define FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
+
+
+// c++ utilities
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// coresoftware headers
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <g4centrality/PHG4CentralityReco.h>
+#include <globalvertex/GlobalVertexReco.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
+#include <mbd/MbdReco.h>
+#include <phool/recoConsts.h>
+#include <qautils/QAHistManagerDef.h>
+#include <zdcinfo/ZdcReco.h>
+
+// f4a macros
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <GlobalVariables.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+// load libraries
+R__LOAD_LIBRARY(libcentrality.so)
+R__LOAD_LIBRARY(libg4centrality.so)
+R__LOAD_LIBRARY(libglobalvertex.so)
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libjetbackground.so)
+R__LOAD_LIBRARY(libjetqa.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libqautils.so)
+R__LOAD_LIBRARY(libzdcinfo.so)
+
+
+
+// ============================================================================
+//! Track jet production macro for year 2 (pp)
+// ============================================================================
+/*! Jet production macro for pp-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary input for track jets:
+ *    - DST_CALO (for beam background filter)
+ *    - DST_TRKR_TRACKS
+ *    - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ */
+void Fun4All_TrackJetProductionYear2(
+  const int nEvents = 0,
+  const std::string& inlist = "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
+  const std::string& dbtag = "ProdA_2024"
+) {
+
+  // set options --------------------------------------------------------------
+
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::NSJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::NSJETS         = true;
+  Enable::NSJETS_TOWER   = false;
+  Enable::NSJETS_TRACK   = true;
+  Enable::NSJETS_PFLOW   = false;
+  NSJETS::is_pp          = true;
+  NSJETS::do_vertex_type = true;
+  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // make sure HIJetReco inputs are the same
+  // for rho calculation
+  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
+  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
+  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
+
+  // qa options
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = NSJETS::is_pp;
+  JetQA::UseBkgdSub       = false;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
+  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = NSJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
+
+  // initialize F4A server
+  Fun4AllServer* se = Fun4AllServer::instance();
+  se -> Verbosity(1);
+
+  // grab 1st file from input lists
+  ifstream    files(inlist);
+  std::string first("");
+  std::getline(files, first);
+
+  // grab run and segment no.s
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(first);
+  int runnumber = runseg.first;
+
+  // set up reconstruction constants, DB tag, timestamp
+  recoConsts* rc = recoConsts::instance();
+  rc -> set_StringFlag("CDB_GLOBALTAG", dbtag);
+  rc -> set_uint64Flag("TIMESTAMP", runnumber);
+
+  // connect to conditions database
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
+
+  // set up flag handler
+  FlagHandler* flag = new FlagHandler();
+  se -> registerSubsystem(flag);
+
+  // read in input
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
+
+  // do vertex & centrality reconstruction
+  Global_Reco();
+  if (!NSJETS::is_pp)
+  {
+    Centrality();
+  }
+
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
+  NoBkgdSubJetReco();
+
+  // register modules necessary for QA
+  if (Enable::QA)
+  {
+    DoRhoCalculation();
+    Jet_QA();
+  }
+
+  // if needed, save DST output
+  if (Enable::DSTOUT)
+  {
+    Fun4AllDstOutputManager* out = new Fun4AllDstOutputManager("DSTOUT", outfile);
+    out -> StripNode("CEMCPackets");
+    out -> StripNode("HCALPackets");
+    out -> StripNode("ZDCPackets");
+    out -> StripNode("SEPDPackets");
+    out -> StripNode("MBDPackets");
+    se -> registerOutputManager(out);
+  }
+
+  // run & exit ---------------------------------------------------------------
+
+  // run4all
+  se -> run(nEvents);
+  se -> End();
+
+  // if needed, save QA output
+  if (Enable::QA)
+  {
+    QAHistManagerDef::saveQARootFile(outfile_hist);
+  }
+
+  // print used DB files, time elapsed and delete server
+  cdb -> Print();
+  se -> PrintTimer();
+  delete se;
+
+  // announce end and exit
+  std::cout << "Jets are done!" << std::endl;
+  gSystem -> Exit(0);
+
+}
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/run2auau/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
+++ b/run2auau/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run2auau/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
+++ b/run2auau/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
@@ -1,5 +1,5 @@
-#ifndef FUN4ALL_JETPRODUCTIONYEAR2_C
-#define FUN4ALL_JETPRODUCTIONYEAR2_C
+#ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
+#define FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
 
 
 // c++ utilities
@@ -33,8 +33,7 @@
 #include <G4_Global.C>
 #include <G4_Magnet.C>
 #include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
+#include <HIJetReco.C>
 #include <Jet_QA.C>
 #include <QA.C>
 #include <Trkr_Reco.C>
@@ -56,32 +55,22 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 // ============================================================================
-//! Jet production macro for year 2 (pp)
+//! Track jet production macro for year 2 (AuAu)
 // ============================================================================
-/*! Jet production macro for pp-running in year 2. Currently used for
+/*! Jet production macro for AuAu-running in year 2. Currently used for
  *  producing for QA. Can be adapted for production of JET DSTs in the
  *  future.
  *
- *  Necessary inputs:
- *    - For calo jets:
- *      - DST_CALO
- *    - For track jets:
- *      - DST_CALO (for beam background filter)
- *      - DST_TRKR_TRACKS
- *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ *  Necessary input for track jets:
+ *    - DST_CALO (for beam background filter)
+ *    - DST_TRKR_TRACKS
+ *    - DST_TRKR_CLUSTER (for tracks-in-jets QA)
  */
-void Fun4All_JetProductionYear2(
+void Fun4All_TrackJetProductionYear2_AuAu(
   const int nEvents = 0,
-  const bool useTwrs = true,
-  const bool useTrks = false,
-  const bool useFlow = false,
-  const std::vector<std::string>& inlists = {
-    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
-  },
+  const std::string& inlist = "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
   const std::string& outfile = "DST_JET-00053877-0000.root",
-  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2aa_tracktest.root",
   const std::string& dbtag = "ProdA_2024"
 ) {
 
@@ -90,39 +79,33 @@ void Fun4All_JetProductionYear2(
   // turn on/off DST output and/or QA
   Enable::DSTOUT           = false;
   Enable::QA               = true;
-  Enable::NSJETS_VERBOSITY = 0;
-  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+  Enable::HIJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::HIJETS_VERBOSITY);
 
   // jet reco options
-  Enable::NSJETS         = true;
-  Enable::NSJETS_TOWER   = useTwrs;
-  Enable::NSJETS_TRACK   = useTrks;
-  Enable::NSJETS_PFLOW   = useFlow;
-  NSJETS::is_pp          = true;
-  NSJETS::do_vertex_type = true;
-  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
-
-  // make sure HIJetReco inputs are the same
-  // for rho calculation
-  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
-  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
-  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
+  Enable::HIJETS         = true;
+  Enable::HIJETS_TOWER   = false;
+  Enable::HIJETS_TRACK   = true;
+  Enable::HIJETS_PFLOW   = false;
+  HIJETS::is_pp          = false;
+  HIJETS::do_vertex_type = true;
+  HIJETS::vertex_type    = Enable::HIJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
 
   // qa options
   JetQA::DoInclusive      = true;
   JetQA::DoTriggered      = true;
-  JetQA::DoPP             = NSJETS::is_pp;
-  JetQA::UseBkgdSub       = false;
+  JetQA::DoPP             = HIJETS::is_pp;
+  JetQA::UseBkgdSub       = true;
   JetQA::RestrictPtToTrig = false;
   JetQA::RestrictEtaByR   = true;
-  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
-  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+  JetQA::HasTracks        = Enable::HIJETS_TRACK || Enable::HIJETS_PFLOW;
+  JetQA::HasCalos         = Enable::HIJETS_TOWER || Enable::HIJETS_PFLOW;
 
   // tracking options
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = NSJETS::is_pp;
+  TRACKING::pp_mode                     = HIJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 
@@ -131,7 +114,7 @@ void Fun4All_JetProductionYear2(
   se -> Verbosity(1);
 
   // grab 1st file from input lists
-  ifstream    files(inlists.front());
+  ifstream    files(inlist);
   std::string first("");
   std::getline(files, first);
 
@@ -153,12 +136,9 @@ void Fun4All_JetProductionYear2(
   se -> registerSubsystem(flag);
 
   // read in input
-  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
-  {
-    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
-    indst -> AddListFile(inlists[iin]);
-    se -> registerInputManager(indst);
-  }
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
 
   // set up tracking
   if (JetQA::HasTracks)
@@ -177,7 +157,7 @@ void Fun4All_JetProductionYear2(
 
   // do vertex & centrality reconstruction
   Global_Reco();
-  if (!NSJETS::is_pp)
+  if (!HIJETS::is_pp)
   {
     Centrality();
   }
@@ -197,7 +177,7 @@ void Fun4All_JetProductionYear2(
   se -> registerSubsystem(filter);
 
   // do jet reconstruction
-  NoBkgdSubJetReco();
+  HIJetReco();  
 
   // register modules necessary for QA
   if (Enable::QA)

--- a/run2auau/JetProduction/runjets.sh
+++ b/run2auau/JetProduction/runjets.sh
@@ -106,8 +106,8 @@ for infile_ in ${inputs[@]}; do
     outhist=${out0/DST/HIST}
 
     echo ${infile} > input.list
-    echo root.exe -q -b Fun4All_JetProductionYear2.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\)
-         root.exe -q -b Fun4All_JetProductionYear2.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\);  status_f4a=$?
+    echo root.exe -q -b Fun4All_CaloJetProductionYear2_AuAu.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\)
+         root.exe -q -b Fun4All_CaloJetProductionYear2_AuAu.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\);  status_f4a=$?
 
     ls -l
 

--- a/run2pp/JetProduction/Fun4All_CaloJetProductionYear2.C
+++ b/run2pp/JetProduction/Fun4All_CaloJetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run2pp/JetProduction/Fun4All_CaloJetProductionYear2.C
+++ b/run2pp/JetProduction/Fun4All_CaloJetProductionYear2.C
@@ -1,0 +1,231 @@
+#ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_C
+#define FUN4ALL_CALOJETPRODUCTIONYEAR2_C
+
+
+// c++ utilities
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// coresoftware headers
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <g4centrality/PHG4CentralityReco.h>
+#include <globalvertex/GlobalVertexReco.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
+#include <mbd/MbdReco.h>
+#include <phool/recoConsts.h>
+#include <qautils/QAHistManagerDef.h>
+#include <zdcinfo/ZdcReco.h>
+
+// f4a macros
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <GlobalVariables.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+// load libraries
+R__LOAD_LIBRARY(libcentrality.so)
+R__LOAD_LIBRARY(libg4centrality.so)
+R__LOAD_LIBRARY(libglobalvertex.so)
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libjetbackground.so)
+R__LOAD_LIBRARY(libjetqa.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libqautils.so)
+R__LOAD_LIBRARY(libzdcinfo.so)
+
+
+
+// ============================================================================
+//! Calorimeter jet production macro for year 2 (pp)
+// ============================================================================
+/*! Jet production macro for pp-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary inputs for calo jets:
+ *    - DST_CALO
+ */
+void Fun4All_CaloJetProductionYear2(
+  const int nEvents = 0,
+  const std::string& inlist = "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
+  const std::string& dbtag = "ProdA_2024"
+) {
+
+  // set options --------------------------------------------------------------
+
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::NSJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::NSJETS         = true;
+  Enable::NSJETS_TOWER   = true;
+  Enable::NSJETS_TRACK   = false;
+  Enable::NSJETS_PFLOW   = false;
+  NSJETS::is_pp          = true;
+  NSJETS::do_vertex_type = true;
+  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // make sure HIJetReco inputs are the same
+  // for rho calculation
+  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
+  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
+  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
+
+  // qa options
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = NSJETS::is_pp;
+  JetQA::UseBkgdSub       = false;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
+  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = NSJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
+
+  // initialize F4A server
+  Fun4AllServer* se = Fun4AllServer::instance();
+  se -> Verbosity(1);
+
+  // grab 1st file from input lists
+  ifstream    files(inlist);
+  std::string first("");
+  std::getline(files, first);
+
+  // grab run and segment no.s
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(first);
+  int runnumber = runseg.first;
+
+  // set up reconstruction constants, DB tag, timestamp
+  recoConsts* rc = recoConsts::instance();
+  rc -> set_StringFlag("CDB_GLOBALTAG", dbtag);
+  rc -> set_uint64Flag("TIMESTAMP", runnumber);
+
+  // connect to conditions database
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
+
+  // set up flag handler
+  FlagHandler* flag = new FlagHandler();
+  se -> registerSubsystem(flag);
+
+  // read in input
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
+
+  // do vertex & centrality reconstruction
+  Global_Reco();
+  if (!NSJETS::is_pp)
+  {
+    Centrality();
+  }
+
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
+  NoBkgdSubJetReco();
+
+  // register modules necessary for QA
+  if (Enable::QA)
+  {
+    DoRhoCalculation();
+    Jet_QA();
+  }
+
+  // if needed, save DST output
+  if (Enable::DSTOUT)
+  {
+    Fun4AllDstOutputManager* out = new Fun4AllDstOutputManager("DSTOUT", outfile);
+    out -> StripNode("CEMCPackets");
+    out -> StripNode("HCALPackets");
+    out -> StripNode("ZDCPackets");
+    out -> StripNode("SEPDPackets");
+    out -> StripNode("MBDPackets");
+    se -> registerOutputManager(out);
+  }
+
+  // run & exit ---------------------------------------------------------------
+
+  // run4all
+  se -> run(nEvents);
+  se -> End();
+
+  // if needed, save QA output
+  if (Enable::QA)
+  {
+    QAHistManagerDef::saveQARootFile(outfile_hist);
+  }
+
+  // print used DB files, time elapsed and delete server
+  cdb -> Print();
+  se -> PrintTimer();
+  delete se;
+
+  // announce end and exit
+  std::cout << "Jets are done!" << std::endl;
+  gSystem -> Exit(0);
+
+}
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/run2pp/JetProduction/Fun4All_JetProductionYear2.C
+++ b/run2pp/JetProduction/Fun4All_JetProductionYear2.C
@@ -21,8 +21,7 @@
 #include <fun4all/Fun4AllUtils.h>
 #include <g4centrality/PHG4CentralityReco.h>
 #include <globalvertex/GlobalVertexReco.h>
-#include <jetbackground/DetermineTowerRho.h>
-#include <jetbackground/TowerRho.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
 #include <mbd/MbdReco.h>
 #include <phool/recoConsts.h>
 #include <qautils/QAHistManagerDef.h>
@@ -34,9 +33,13 @@
 #include <G4_Global.C>
 #include <G4_Magnet.C>
 #include <GlobalVariables.C>
-#include <HIJetReco.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
 #include <Jet_QA.C>
 #include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)
@@ -52,36 +55,83 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 
-// macro body -----------------------------------------------------------------
-
+// ============================================================================
+//! Jet production macro for year 2 (pp)
+// ============================================================================
+/*! Jet production macro for pp-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary inputs:
+ *    - For calo jets:
+ *      - DST_CALO
+ *    - For track jets:
+ *      - DST_CALO (for beam background filter)
+ *      - DST_TRKR_TRACKS
+ *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ */
 void Fun4All_JetProductionYear2(
   const int nEvents = 0,
-  const std::string& inlist = "TestListInput.list",
-  const std::string& outfile = "DST_JET-00042586-0000.root",
-  const std::string& outfile_hist = "HIST_JETQA-00042586-0000.root",
+  const bool useTwrs = true,
+  const bool useTrks = false,
+  const bool useFlow = false,
+  const std::vector<std::string>& inlists = {
+    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
+  },
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
   const std::string& dbtag = "ProdA_2024"
 ) {
 
-  // turn on/off DST output and/or QA
-  Enable::DSTOUT = false;
-  Enable::QA = true;
+  // set options --------------------------------------------------------------
 
-  // turn on pp mode
-  HIJETS::is_pp = true;
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::NSJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::NSJETS         = true;
+  Enable::NSJETS_TOWER   = useTwrs;
+  Enable::NSJETS_TRACK   = useTrks;
+  Enable::NSJETS_PFLOW   = useFlow;
+  NSJETS::is_pp          = true;
+  NSJETS::do_vertex_type = true;
+  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // make sure HIJetReco inputs are the same
+  // for rho calculation
+  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
+  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
+  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
 
   // qa options
-  JetQA::HasTracks = false;
-  JetQA::DoInclusive = true;
-  JetQA::DoTriggered = true;
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = NSJETS::is_pp;
+  JetQA::UseBkgdSub       = false;
   JetQA::RestrictPtToTrig = false;
-  JetQA::RestrictEtaByR = true;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
+  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = NSJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
 
   // initialize F4A server
   Fun4AllServer* se = Fun4AllServer::instance();
   se -> Verbosity(1);
 
-  // grab 1st file from input list
-  ifstream    files(inlist);
+  // grab 1st file from input lists
+  ifstream    files(inlists.front());
   std::string first("");
   std::getline(files, first);
 
@@ -95,26 +145,59 @@ void Fun4All_JetProductionYear2(
   rc -> set_uint64Flag("TIMESTAMP", runnumber);
 
   // connect to conditions database
-  CDBInterface::instance()->Verbosity(1);
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
 
   // set up flag handler
   FlagHandler* flag = new FlagHandler();
   se -> registerSubsystem(flag);
 
   // read in input
-  Fun4AllInputManager* in = new Fun4AllDstInputManager("in");
-  in -> AddListFile(inlist);
-  se -> registerInputManager(in);
+  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
+  {
+    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
+    indst -> AddListFile(inlists[iin]);
+    se -> registerInputManager(indst);
+  }
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
 
   // do vertex & centrality reconstruction
   Global_Reco();
-  if (!HIJETS::is_pp)
+  if (!NSJETS::is_pp)
   {
     Centrality();
   }
 
-  // do jet reconstruction & rho calculation
-  HIJetReco();  
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
+  NoBkgdSubJetReco();
 
   // register modules necessary for QA
   if (Enable::QA)
@@ -135,6 +218,8 @@ void Fun4All_JetProductionYear2(
     se -> registerOutputManager(out);
   }
 
+  // run & exit ---------------------------------------------------------------
+
   // run4all
   se -> run(nEvents);
   se -> End();
@@ -146,7 +231,7 @@ void Fun4All_JetProductionYear2(
   }
 
   // print used DB files, time elapsed and delete server
-  CDBInterface::instance() -> Print();
+  cdb -> Print();
   se -> PrintTimer();
   delete se;
 

--- a/run2pp/JetProduction/Fun4All_TrackJetProductionYear2.C
+++ b/run2pp/JetProduction/Fun4All_TrackJetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run2pp/JetProduction/Fun4All_TrackJetProductionYear2.C
+++ b/run2pp/JetProduction/Fun4All_TrackJetProductionYear2.C
@@ -1,0 +1,233 @@
+#ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
+#define FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
+
+
+// c++ utilities
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// coresoftware headers
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <g4centrality/PHG4CentralityReco.h>
+#include <globalvertex/GlobalVertexReco.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
+#include <mbd/MbdReco.h>
+#include <phool/recoConsts.h>
+#include <qautils/QAHistManagerDef.h>
+#include <zdcinfo/ZdcReco.h>
+
+// f4a macros
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <GlobalVariables.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+// load libraries
+R__LOAD_LIBRARY(libcentrality.so)
+R__LOAD_LIBRARY(libg4centrality.so)
+R__LOAD_LIBRARY(libglobalvertex.so)
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libjetbackground.so)
+R__LOAD_LIBRARY(libjetqa.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libqautils.so)
+R__LOAD_LIBRARY(libzdcinfo.so)
+
+
+
+// ============================================================================
+//! Track jet production macro for year 2 (pp)
+// ============================================================================
+/*! Jet production macro for pp-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary input for track jets:
+ *    - DST_CALO (for beam background filter)
+ *    - DST_TRKR_TRACKS
+ *    - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ */
+void Fun4All_TrackJetProductionYear2(
+  const int nEvents = 0,
+  const std::string& inlist = "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
+  const std::string& dbtag = "ProdA_2024"
+) {
+
+  // set options --------------------------------------------------------------
+
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::NSJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::NSJETS         = true;
+  Enable::NSJETS_TOWER   = false;
+  Enable::NSJETS_TRACK   = true;
+  Enable::NSJETS_PFLOW   = false;
+  NSJETS::is_pp          = true;
+  NSJETS::do_vertex_type = true;
+  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // make sure HIJetReco inputs are the same
+  // for rho calculation
+  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
+  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
+  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
+
+  // qa options
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = NSJETS::is_pp;
+  JetQA::UseBkgdSub       = false;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
+  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = NSJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
+
+  // initialize F4A server
+  Fun4AllServer* se = Fun4AllServer::instance();
+  se -> Verbosity(1);
+
+  // grab 1st file from input lists
+  ifstream    files(inlist);
+  std::string first("");
+  std::getline(files, first);
+
+  // grab run and segment no.s
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(first);
+  int runnumber = runseg.first;
+
+  // set up reconstruction constants, DB tag, timestamp
+  recoConsts* rc = recoConsts::instance();
+  rc -> set_StringFlag("CDB_GLOBALTAG", dbtag);
+  rc -> set_uint64Flag("TIMESTAMP", runnumber);
+
+  // connect to conditions database
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
+
+  // set up flag handler
+  FlagHandler* flag = new FlagHandler();
+  se -> registerSubsystem(flag);
+
+  // read in input
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
+
+  // do vertex & centrality reconstruction
+  Global_Reco();
+  if (!NSJETS::is_pp)
+  {
+    Centrality();
+  }
+
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
+  NoBkgdSubJetReco();
+
+  // register modules necessary for QA
+  if (Enable::QA)
+  {
+    DoRhoCalculation();
+    Jet_QA();
+  }
+
+  // if needed, save DST output
+  if (Enable::DSTOUT)
+  {
+    Fun4AllDstOutputManager* out = new Fun4AllDstOutputManager("DSTOUT", outfile);
+    out -> StripNode("CEMCPackets");
+    out -> StripNode("HCALPackets");
+    out -> StripNode("ZDCPackets");
+    out -> StripNode("SEPDPackets");
+    out -> StripNode("MBDPackets");
+    se -> registerOutputManager(out);
+  }
+
+  // run & exit ---------------------------------------------------------------
+
+  // run4all
+  se -> run(nEvents);
+  se -> End();
+
+  // if needed, save QA output
+  if (Enable::QA)
+  {
+    QAHistManagerDef::saveQARootFile(outfile_hist);
+  }
+
+  // print used DB files, time elapsed and delete server
+  cdb -> Print();
+  se -> PrintTimer();
+  delete se;
+
+  // announce end and exit
+  std::cout << "Jets are done!" << std::endl;
+  gSystem -> Exit(0);
+
+}
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/run2pp/JetProduction/runjets.sh
+++ b/run2pp/JetProduction/runjets.sh
@@ -107,8 +107,8 @@ for infile_ in ${inputs[@]}; do
     outhist=${out0/DST/HIST}
 
     echo ${infile} > input.list
-    echo root.exe -q -b Fun4All_JetProductionYear2.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\)
-         root.exe -q -b Fun4All_JetProductionYear2.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\);  status_f4a=$?
+    echo root.exe -q -b Fun4All_CaloJetProductionYear2.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\)
+         root.exe -q -b Fun4All_CaloJetProductionYear2.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\);  status_f4a=$?
 
     ls -l
 

--- a/run3auau/JetProduction/Fun4All_CaloJetProductionYear2.C
+++ b/run3auau/JetProduction/Fun4All_CaloJetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run3auau/JetProduction/Fun4All_CaloJetProductionYear2.C
+++ b/run3auau/JetProduction/Fun4All_CaloJetProductionYear2.C
@@ -1,0 +1,231 @@
+#ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_C
+#define FUN4ALL_CALOJETPRODUCTIONYEAR2_C
+
+
+// c++ utilities
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// coresoftware headers
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <g4centrality/PHG4CentralityReco.h>
+#include <globalvertex/GlobalVertexReco.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
+#include <mbd/MbdReco.h>
+#include <phool/recoConsts.h>
+#include <qautils/QAHistManagerDef.h>
+#include <zdcinfo/ZdcReco.h>
+
+// f4a macros
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <GlobalVariables.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+// load libraries
+R__LOAD_LIBRARY(libcentrality.so)
+R__LOAD_LIBRARY(libg4centrality.so)
+R__LOAD_LIBRARY(libglobalvertex.so)
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libjetbackground.so)
+R__LOAD_LIBRARY(libjetqa.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libqautils.so)
+R__LOAD_LIBRARY(libzdcinfo.so)
+
+
+
+// ============================================================================
+//! Calorimeter jet production macro for year 2 (pp)
+// ============================================================================
+/*! Jet production macro for pp-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary inputs for calo jets:
+ *    - DST_CALO
+ */
+void Fun4All_CaloJetProductionYear2(
+  const int nEvents = 0,
+  const std::string& inlist = "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
+  const std::string& dbtag = "ProdA_2024"
+) {
+
+  // set options --------------------------------------------------------------
+
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::NSJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::NSJETS         = true;
+  Enable::NSJETS_TOWER   = true;
+  Enable::NSJETS_TRACK   = false;
+  Enable::NSJETS_PFLOW   = false;
+  NSJETS::is_pp          = true;
+  NSJETS::do_vertex_type = true;
+  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // make sure HIJetReco inputs are the same
+  // for rho calculation
+  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
+  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
+  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
+
+  // qa options
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = NSJETS::is_pp;
+  JetQA::UseBkgdSub       = false;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
+  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = NSJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
+
+  // initialize F4A server
+  Fun4AllServer* se = Fun4AllServer::instance();
+  se -> Verbosity(1);
+
+  // grab 1st file from input lists
+  ifstream    files(inlist);
+  std::string first("");
+  std::getline(files, first);
+
+  // grab run and segment no.s
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(first);
+  int runnumber = runseg.first;
+
+  // set up reconstruction constants, DB tag, timestamp
+  recoConsts* rc = recoConsts::instance();
+  rc -> set_StringFlag("CDB_GLOBALTAG", dbtag);
+  rc -> set_uint64Flag("TIMESTAMP", runnumber);
+
+  // connect to conditions database
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
+
+  // set up flag handler
+  FlagHandler* flag = new FlagHandler();
+  se -> registerSubsystem(flag);
+
+  // read in input
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
+
+  // do vertex & centrality reconstruction
+  Global_Reco();
+  if (!NSJETS::is_pp)
+  {
+    Centrality();
+  }
+
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
+  NoBkgdSubJetReco();
+
+  // register modules necessary for QA
+  if (Enable::QA)
+  {
+    DoRhoCalculation();
+    Jet_QA();
+  }
+
+  // if needed, save DST output
+  if (Enable::DSTOUT)
+  {
+    Fun4AllDstOutputManager* out = new Fun4AllDstOutputManager("DSTOUT", outfile);
+    out -> StripNode("CEMCPackets");
+    out -> StripNode("HCALPackets");
+    out -> StripNode("ZDCPackets");
+    out -> StripNode("SEPDPackets");
+    out -> StripNode("MBDPackets");
+    se -> registerOutputManager(out);
+  }
+
+  // run & exit ---------------------------------------------------------------
+
+  // run4all
+  se -> run(nEvents);
+  se -> End();
+
+  // if needed, save QA output
+  if (Enable::QA)
+  {
+    QAHistManagerDef::saveQARootFile(outfile_hist);
+  }
+
+  // print used DB files, time elapsed and delete server
+  cdb -> Print();
+  se -> PrintTimer();
+  delete se;
+
+  // announce end and exit
+  std::cout << "Jets are done!" << std::endl;
+  gSystem -> Exit(0);
+
+}
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/run3auau/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
+++ b/run3auau/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run3auau/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
+++ b/run3auau/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
@@ -1,5 +1,6 @@
-#ifndef FUN4ALL_JETPRODUCTIONYEAR2_AUAU_C
-#define FUN4ALL_JETPRODUCTIONYEAR2_AUAU_C
+#ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
+#define FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
+
 
 // c++ utilities
 #include <fstream>
@@ -54,30 +55,18 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 // ============================================================================
-//! Jet production macro for year 2 (AuAu)
+//! Calorimeter jet production macro for year 2 (AuAu)
 // ============================================================================
 /*! Jet production macro for AuAu-running in year 2. Currently used for
  *  producing for QA. Can be adapted for production of JET DSTs in the
  *  future.
  *
- *  Necessary inputs:
- *    - For calo jets:
- *      - DST_CALO
- *    - For track jets:
- *      - DST_CALO (for beam background filter)
- *      - DST_TRKR_TRACKS
- *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ *  Necessary inputs for calo jets:
+ *    - DST_CALO
  */
-void Fun4All_JetProductionYear2_AuAu(
+void Fun4All_CaloJetProductionYear2_AuAu(
   const int nEvents = 0,
-  const bool useTwrs = true,
-  const bool useTrks = false,
-  const bool useFlow = false,
-  const std::vector<std::string>& inlists = {
-    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
-  },
+  const std::string& inlist =  "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
   const std::string& outfile = "DST_JET-00053877-0000.root",
   const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2aa_tracktest.root",
   const std::string& dbtag = "ProdA_2024"
@@ -93,9 +82,9 @@ void Fun4All_JetProductionYear2_AuAu(
 
   // jet reco options
   Enable::HIJETS         = true;
-  Enable::HIJETS_TOWER   = useTwrs;
-  Enable::HIJETS_TRACK   = useTrks;
-  Enable::HIJETS_PFLOW   = useFlow;
+  Enable::HIJETS_TOWER   = true;
+  Enable::HIJETS_TRACK   = false;
+  Enable::HIJETS_PFLOW   = false;
   HIJETS::is_pp          = false;
   HIJETS::do_vertex_type = true;
   HIJETS::vertex_type    = Enable::HIJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
@@ -120,10 +109,10 @@ void Fun4All_JetProductionYear2_AuAu(
 
   // initialize F4A server
   Fun4AllServer* se = Fun4AllServer::instance();
-  se -> Verbosity(0);
+  se -> Verbosity(1);
 
   // grab 1st file from input lists
-  ifstream    files(inlists.front());
+  ifstream    files(inlist);
   std::string first("");
   std::getline(files, first);
 
@@ -145,12 +134,9 @@ void Fun4All_JetProductionYear2_AuAu(
   se -> registerSubsystem(flag);
 
   // read in input
-  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
-  {
-    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
-    indst -> AddListFile(inlists[iin]);
-    se -> registerInputManager(indst);
-  }
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
 
   // set up tracking
   if (JetQA::HasTracks)

--- a/run3auau/JetProduction/Fun4All_CaloJetProductionYear3.C
+++ b/run3auau/JetProduction/Fun4All_CaloJetProductionYear3.C
@@ -1,0 +1,224 @@
+#ifndef FUN4ALL_CALOJETPRODUCTIONYEAR3_C
+#define FUN4ALL_CALOJETPRODUCTIONYEAR3_C
+
+
+// c++ utilities
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// coresoftware headers
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <g4centrality/PHG4CentralityReco.h>
+#include <globalvertex/GlobalVertexReco.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
+#include <mbd/MbdReco.h>
+#include <phool/recoConsts.h>
+#include <qautils/QAHistManagerDef.h>
+#include <zdcinfo/ZdcReco.h>
+
+// f4a macros
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <GlobalVariables.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+// load libraries
+R__LOAD_LIBRARY(libcentrality.so)
+R__LOAD_LIBRARY(libg4centrality.so)
+R__LOAD_LIBRARY(libglobalvertex.so)
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libjetbackground.so)
+R__LOAD_LIBRARY(libjetqa.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libqautils.so)
+R__LOAD_LIBRARY(libzdcinfo.so)
+
+
+
+// ============================================================================
+//! Calorimeter jet production macro for year 3 (AuAu)
+// ============================================================================
+/*! Jet production macro for AuAu-running in year 3. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary inputs for calo jets:
+ *    - DST_CALO
+ */
+void Fun4All_CaloJetProductionYear3(
+  const int nEvents = 0,
+  const std::string& inlist =  "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2aa_tracktest.root",
+  const std::string& dbtag = "ProdA_2024"
+) {
+
+  // set options --------------------------------------------------------------
+
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::HIJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::HIJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::HIJETS         = true;
+  Enable::HIJETS_TOWER   = true;
+  Enable::HIJETS_TRACK   = false;
+  Enable::HIJETS_PFLOW   = false;
+  HIJETS::is_pp          = false;
+  HIJETS::do_vertex_type = true;
+  HIJETS::vertex_type    = Enable::HIJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // qa options
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = HIJETS::is_pp;
+  JetQA::UseBkgdSub       = true;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::HIJETS_TRACK || Enable::HIJETS_PFLOW;
+  JetQA::HasCalos         = Enable::HIJETS_TOWER || Enable::HIJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = HIJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
+
+  // initialize F4A server
+  Fun4AllServer* se = Fun4AllServer::instance();
+  se -> Verbosity(1);
+
+  // grab 1st file from input lists
+  ifstream    files(inlist);
+  std::string first("");
+  std::getline(files, first);
+
+  // grab run and segment no.s
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(first);
+  int runnumber = runseg.first;
+
+  // set up reconstruction constants, DB tag, timestamp
+  recoConsts* rc = recoConsts::instance();
+  rc -> set_StringFlag("CDB_GLOBALTAG", dbtag);
+  rc -> set_uint64Flag("TIMESTAMP", runnumber);
+
+  // connect to conditions database
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
+
+  // set up flag handler
+  FlagHandler* flag = new FlagHandler();
+  se -> registerSubsystem(flag);
+
+  // read in input
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
+
+  // do vertex & centrality reconstruction
+  Global_Reco();
+  if (!HIJETS::is_pp)
+  {
+    Centrality();
+  }
+
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
+  HIJetReco();  
+
+  // register modules necessary for QA
+  if (Enable::QA)
+  {
+    DoRhoCalculation();
+    Jet_QA();
+  }
+
+  // if needed, save DST output
+  if (Enable::DSTOUT)
+  {
+    Fun4AllDstOutputManager* out = new Fun4AllDstOutputManager("DSTOUT", outfile);
+    out -> StripNode("CEMCPackets");
+    out -> StripNode("HCALPackets");
+    out -> StripNode("ZDCPackets");
+    out -> StripNode("SEPDPackets");
+    out -> StripNode("MBDPackets");
+    se -> registerOutputManager(out);
+  }
+
+  // run & exit ---------------------------------------------------------------
+
+  // run4all
+  se -> run(nEvents);
+  se -> End();
+
+  // if needed, save QA output
+  if (Enable::QA)
+  {
+    QAHistManagerDef::saveQARootFile(outfile_hist);
+  }
+
+  // print used DB files, time elapsed and delete server
+  cdb -> Print();
+  se -> PrintTimer();
+  delete se;
+
+  // announce end and exit
+  std::cout << "Jets are done!" << std::endl;
+  gSystem -> Exit(0);
+
+}
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/run3auau/JetProduction/Fun4All_CaloJetProductionYear3.C
+++ b/run3auau/JetProduction/Fun4All_CaloJetProductionYear3.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR3_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR3_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run3auau/JetProduction/Fun4All_JetProductionYear2.C
+++ b/run3auau/JetProduction/Fun4All_JetProductionYear2.C
@@ -21,8 +21,7 @@
 #include <fun4all/Fun4AllUtils.h>
 #include <g4centrality/PHG4CentralityReco.h>
 #include <globalvertex/GlobalVertexReco.h>
-#include <jetbackground/DetermineTowerRho.h>
-#include <jetbackground/TowerRho.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
 #include <mbd/MbdReco.h>
 #include <phool/recoConsts.h>
 #include <qautils/QAHistManagerDef.h>
@@ -34,9 +33,13 @@
 #include <G4_Global.C>
 #include <G4_Magnet.C>
 #include <GlobalVariables.C>
-#include <HIJetReco.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
 #include <Jet_QA.C>
 #include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)
@@ -52,36 +55,83 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 
-// macro body -----------------------------------------------------------------
-
+// ============================================================================
+//! Jet production macro for year 2 (pp)
+// ============================================================================
+/*! Jet production macro for pp-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary inputs:
+ *    - For calo jets:
+ *      - DST_CALO
+ *    - For track jets:
+ *      - DST_CALO (for beam background filter)
+ *      - DST_TRKR_TRACKS
+ *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ */
 void Fun4All_JetProductionYear2(
   const int nEvents = 0,
-  const std::string& inlist = "TestListInput.list",
-  const std::string& outfile = "DST_JET-00042586-0000.root",
-  const std::string& outfile_hist = "HIST_JETQA-00042586-0000.root",
+  const bool useTwrs = true,
+  const bool useTrks = false,
+  const bool useFlow = false,
+  const std::vector<std::string>& inlists = {
+    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
+  },
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
   const std::string& dbtag = "ProdA_2024"
 ) {
 
-  // turn on/off DST output and/or QA
-  Enable::DSTOUT = false;
-  Enable::QA = true;
+  // set options --------------------------------------------------------------
 
-  // turn on pp mode
-  HIJETS::is_pp = true;
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::NSJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::NSJETS         = true;
+  Enable::NSJETS_TOWER   = useTwrs;
+  Enable::NSJETS_TRACK   = useTrks;
+  Enable::NSJETS_PFLOW   = useFlow;
+  NSJETS::is_pp          = true;
+  NSJETS::do_vertex_type = true;
+  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // make sure HIJetReco inputs are the same
+  // for rho calculation
+  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
+  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
+  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
 
   // qa options
-  JetQA::HasTracks = false;
-  JetQA::DoInclusive = true;
-  JetQA::DoTriggered = true;
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = NSJETS::is_pp;
+  JetQA::UseBkgdSub       = false;
   JetQA::RestrictPtToTrig = false;
-  JetQA::RestrictEtaByR = true;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
+  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = NSJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
 
   // initialize F4A server
   Fun4AllServer* se = Fun4AllServer::instance();
   se -> Verbosity(1);
 
-  // grab 1st file from input list
-  ifstream    files(inlist);
+  // grab 1st file from input lists
+  ifstream    files(inlists.front());
   std::string first("");
   std::getline(files, first);
 
@@ -95,26 +145,59 @@ void Fun4All_JetProductionYear2(
   rc -> set_uint64Flag("TIMESTAMP", runnumber);
 
   // connect to conditions database
-  CDBInterface::instance()->Verbosity(1);
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
 
   // set up flag handler
   FlagHandler* flag = new FlagHandler();
   se -> registerSubsystem(flag);
 
   // read in input
-  Fun4AllInputManager* in = new Fun4AllDstInputManager("in");
-  in -> AddListFile(inlist);
-  se -> registerInputManager(in);
+  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
+  {
+    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
+    indst -> AddListFile(inlists[iin]);
+    se -> registerInputManager(indst);
+  }
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
 
   // do vertex & centrality reconstruction
   Global_Reco();
-  if (!HIJETS::is_pp)
+  if (!NSJETS::is_pp)
   {
     Centrality();
   }
 
-  // do jet reconstruction & rho calculation
-  HIJetReco();  
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
+  NoBkgdSubJetReco();
 
   // register modules necessary for QA
   if (Enable::QA)
@@ -135,6 +218,8 @@ void Fun4All_JetProductionYear2(
     se -> registerOutputManager(out);
   }
 
+  // run & exit ---------------------------------------------------------------
+
   // run4all
   se -> run(nEvents);
   se -> End();
@@ -146,7 +231,7 @@ void Fun4All_JetProductionYear2(
   }
 
   // print used DB files, time elapsed and delete server
-  CDBInterface::instance() -> Print();
+  cdb -> Print();
   se -> PrintTimer();
   delete se;
 

--- a/run3auau/JetProduction/Fun4All_JetProductionYear2_AuAu.C
+++ b/run3auau/JetProduction/Fun4All_JetProductionYear2_AuAu.C
@@ -20,8 +20,7 @@
 #include <fun4all/Fun4AllUtils.h>
 #include <g4centrality/PHG4CentralityReco.h>
 #include <globalvertex/GlobalVertexReco.h>
-#include <jetbackground/DetermineTowerRho.h>
-#include <jetbackground/TowerRho.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
 #include <mbd/MbdReco.h>
 #include <phool/recoConsts.h>
 #include <qautils/QAHistManagerDef.h>
@@ -36,6 +35,9 @@
 #include <HIJetReco.C>
 #include <Jet_QA.C>
 #include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)
@@ -51,36 +53,77 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 
-// macro body -----------------------------------------------------------------
-
+// ============================================================================
+//! Jet production macro for year 2 (AuAu)
+// ============================================================================
+/*! Jet production macro for AuAu-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary inputs:
+ *    - For calo jets:
+ *      - DST_CALO
+ *    - For track jets:
+ *      - DST_CALO (for beam background filter)
+ *      - DST_TRKR_TRACKS
+ *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ */
 void Fun4All_JetProductionYear2_AuAu(
   const int nEvents = 0,
-  const std::string& inlist = "TestListInput.list",
-  const std::string& outfile = "DST_JET-00042586-0000.root",
-  const std::string& outfile_hist = "HIST_JETQA-00042586-0000.root",
+  const bool useTwrs = true,
+  const bool useTrks = false,
+  const bool useFlow = false,
+  const std::vector<std::string>& inlists = {
+    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
+  },
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2aa_tracktest.root",
   const std::string& dbtag = "ProdA_2024"
 ) {
 
-  // turn on/off DST output and/or QA
-  Enable::DSTOUT = false;
-  Enable::QA = true;
+  // set options --------------------------------------------------------------
 
-  // turn on pp mode
-  HIJETS::is_pp = false;
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::HIJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::HIJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::HIJETS         = true;
+  Enable::HIJETS_TOWER   = useTwrs;
+  Enable::HIJETS_TRACK   = useTrks;
+  Enable::HIJETS_PFLOW   = useFlow;
+  HIJETS::is_pp          = false;
+  HIJETS::do_vertex_type = true;
+  HIJETS::vertex_type    = Enable::HIJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
 
   // qa options
-  JetQA::HasTracks = false;
-  JetQA::DoInclusive = true;
-  JetQA::DoTriggered = true;
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = HIJETS::is_pp;
+  JetQA::UseBkgdSub       = true;
   JetQA::RestrictPtToTrig = false;
-  JetQA::RestrictEtaByR = true;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::HIJETS_TRACK || Enable::HIJETS_PFLOW;
+  JetQA::HasCalos         = Enable::HIJETS_TOWER || Enable::HIJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = HIJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
 
   // initialize F4A server
   Fun4AllServer* se = Fun4AllServer::instance();
   se -> Verbosity(1);
 
-  // grab 1st file from input list
-  ifstream    files(inlist);
+  // grab 1st file from input lists
+  ifstream    files(inlists.front());
   std::string first("");
   std::getline(files, first);
 
@@ -94,16 +137,35 @@ void Fun4All_JetProductionYear2_AuAu(
   rc -> set_uint64Flag("TIMESTAMP", runnumber);
 
   // connect to conditions database
-  CDBInterface::instance()->Verbosity(1);
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
 
   // set up flag handler
   FlagHandler* flag = new FlagHandler();
   se -> registerSubsystem(flag);
 
   // read in input
-  Fun4AllInputManager* in = new Fun4AllDstInputManager("in");
-  in -> AddListFile(inlist);
-  se -> registerInputManager(in);
+  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
+  {
+    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
+    indst -> AddListFile(inlists[iin]);
+    se -> registerInputManager(indst);
+  }
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
 
   // do vertex & centrality reconstruction
   Global_Reco();
@@ -112,7 +174,21 @@ void Fun4All_JetProductionYear2_AuAu(
     Centrality();
   }
 
-  // do jet reconstruction & rho calculation
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
   HIJetReco();  
 
   // register modules necessary for QA
@@ -134,6 +210,8 @@ void Fun4All_JetProductionYear2_AuAu(
     se -> registerOutputManager(out);
   }
 
+  // run & exit ---------------------------------------------------------------
+
   // run4all
   se -> run(nEvents);
   se -> End();
@@ -145,7 +223,7 @@ void Fun4All_JetProductionYear2_AuAu(
   }
 
   // print used DB files, time elapsed and delete server
-  CDBInterface::instance() -> Print();
+  cdb -> Print();
   se -> PrintTimer();
   delete se;
 

--- a/run3auau/JetProduction/Fun4All_TrackJetProductionYear2.C
+++ b/run3auau/JetProduction/Fun4All_TrackJetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run3auau/JetProduction/Fun4All_TrackJetProductionYear2.C
+++ b/run3auau/JetProduction/Fun4All_TrackJetProductionYear2.C
@@ -1,0 +1,233 @@
+#ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
+#define FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
+
+
+// c++ utilities
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// coresoftware headers
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <g4centrality/PHG4CentralityReco.h>
+#include <globalvertex/GlobalVertexReco.h>
+#include <jetbackground/BeamBackgroundFilterAndQA.h>
+#include <mbd/MbdReco.h>
+#include <phool/recoConsts.h>
+#include <qautils/QAHistManagerDef.h>
+#include <zdcinfo/ZdcReco.h>
+
+// f4a macros
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <GlobalVariables.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+// load libraries
+R__LOAD_LIBRARY(libcentrality.so)
+R__LOAD_LIBRARY(libg4centrality.so)
+R__LOAD_LIBRARY(libglobalvertex.so)
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libjetbackground.so)
+R__LOAD_LIBRARY(libjetqa.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libqautils.so)
+R__LOAD_LIBRARY(libzdcinfo.so)
+
+
+
+// ============================================================================
+//! Track jet production macro for year 2 (pp)
+// ============================================================================
+/*! Jet production macro for pp-running in year 2. Currently used for
+ *  producing for QA. Can be adapted for production of JET DSTs in the
+ *  future.
+ *
+ *  Necessary input for track jets:
+ *    - DST_CALO (for beam background filter)
+ *    - DST_TRKR_TRACKS
+ *    - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ */
+void Fun4All_TrackJetProductionYear2(
+  const int nEvents = 0,
+  const std::string& inlist = "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
+  const std::string& outfile = "DST_JET-00053877-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
+  const std::string& dbtag = "ProdA_2024"
+) {
+
+  // set options --------------------------------------------------------------
+
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT           = false;
+  Enable::QA               = true;
+  Enable::NSJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+
+  // jet reco options
+  Enable::NSJETS         = true;
+  Enable::NSJETS_TOWER   = false;
+  Enable::NSJETS_TRACK   = true;
+  Enable::NSJETS_PFLOW   = false;
+  NSJETS::is_pp          = true;
+  NSJETS::do_vertex_type = true;
+  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
+
+  // make sure HIJetReco inputs are the same
+  // for rho calculation
+  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
+  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
+  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
+
+  // qa options
+  JetQA::DoInclusive      = true;
+  JetQA::DoTriggered      = true;
+  JetQA::DoPP             = NSJETS::is_pp;
+  JetQA::UseBkgdSub       = false;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR   = true;
+  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
+  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+
+  // tracking options
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  Enable::MVTX_APPLYMISALIGNMENT        = true;
+  ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::pp_mode                     = NSJETS::is_pp;
+
+  // initialize interfaces, register inputs -----------------------------------
+
+  // initialize F4A server
+  Fun4AllServer* se = Fun4AllServer::instance();
+  se -> Verbosity(1);
+
+  // grab 1st file from input lists
+  ifstream    files(inlist);
+  std::string first("");
+  std::getline(files, first);
+
+  // grab run and segment no.s
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(first);
+  int runnumber = runseg.first;
+
+  // set up reconstruction constants, DB tag, timestamp
+  recoConsts* rc = recoConsts::instance();
+  rc -> set_StringFlag("CDB_GLOBALTAG", dbtag);
+  rc -> set_uint64Flag("TIMESTAMP", runnumber);
+
+  // connect to conditions database
+  CDBInterface* cdb = CDBInterface::instance();
+  cdb -> Verbosity(1);
+
+  // set up flag handler
+  FlagHandler* flag = new FlagHandler();
+  se -> registerSubsystem(flag);
+
+  // read in input
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
+
+  // set up tracking
+  if (JetQA::HasTracks)
+  {
+    // register tracking geometry
+    Fun4AllRunNodeInputManager* ingeom = new Fun4AllRunNodeInputManager("ingeom");
+    ingeom -> AddFile(cdb -> getUrl("Tracking_Geometry"));
+    se -> registerInputManager(ingeom);
+
+    // initialize tracking
+    TpcReadoutInit(runnumber);
+    TrackingInit();
+  }
+
+  // register reconstruction modules ------------------------------------------
+
+  // do vertex & centrality reconstruction
+  Global_Reco();
+  if (!NSJETS::is_pp)
+  {
+    Centrality();
+  }
+
+  // filter out beam-background events (use default parameters for
+  // streak-sideband filter)
+  BeamBackgroundFilterAndQA* filter = new BeamBackgroundFilterAndQA("BeamBackgroundFilterAndQA");
+  filter -> Verbosity(std::max(Enable::QA_VERBOSITY, Enable::JETQA_VERBOSITY));
+  filter -> SetConfig(
+    {
+      .debug          = false,
+      .doQA           = Enable::QA,
+      .doEvtAbort     = false,
+      .filtersToApply = {"StreakSideband"}
+    }
+  );
+  se -> registerSubsystem(filter);
+
+  // do jet reconstruction
+  NoBkgdSubJetReco();
+
+  // register modules necessary for QA
+  if (Enable::QA)
+  {
+    DoRhoCalculation();
+    Jet_QA();
+  }
+
+  // if needed, save DST output
+  if (Enable::DSTOUT)
+  {
+    Fun4AllDstOutputManager* out = new Fun4AllDstOutputManager("DSTOUT", outfile);
+    out -> StripNode("CEMCPackets");
+    out -> StripNode("HCALPackets");
+    out -> StripNode("ZDCPackets");
+    out -> StripNode("SEPDPackets");
+    out -> StripNode("MBDPackets");
+    se -> registerOutputManager(out);
+  }
+
+  // run & exit ---------------------------------------------------------------
+
+  // run4all
+  se -> run(nEvents);
+  se -> End();
+
+  // if needed, save QA output
+  if (Enable::QA)
+  {
+    QAHistManagerDef::saveQARootFile(outfile_hist);
+  }
+
+  // print used DB files, time elapsed and delete server
+  cdb -> Print();
+  se -> PrintTimer();
+  delete se;
+
+  // announce end and exit
+  std::cout << "Jets are done!" << std::endl;
+  gSystem -> Exit(0);
+
+}
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/run3auau/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
+++ b/run3auau/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run3auau/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
+++ b/run3auau/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
@@ -1,5 +1,5 @@
-#ifndef FUN4ALL_JETPRODUCTIONYEAR2_C
-#define FUN4ALL_JETPRODUCTIONYEAR2_C
+#ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
+#define FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
 
 
 // c++ utilities
@@ -33,8 +33,7 @@
 #include <G4_Global.C>
 #include <G4_Magnet.C>
 #include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
+#include <HIJetReco.C>
 #include <Jet_QA.C>
 #include <QA.C>
 #include <Trkr_Reco.C>
@@ -56,32 +55,22 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 
 
 // ============================================================================
-//! Jet production macro for year 2 (pp)
+//! Track jet production macro for year 2 (AuAu)
 // ============================================================================
-/*! Jet production macro for pp-running in year 2. Currently used for
+/*! Jet production macro for AuAu-running in year 2. Currently used for
  *  producing for QA. Can be adapted for production of JET DSTs in the
  *  future.
  *
- *  Necessary inputs:
- *    - For calo jets:
- *      - DST_CALO
- *    - For track jets:
- *      - DST_CALO (for beam background filter)
- *      - DST_TRKR_TRACKS
- *      - DST_TRKR_CLUSTER (for tracks-in-jets QA)
+ *  Necessary input for track jets:
+ *    - DST_CALO (for beam background filter)
+ *    - DST_TRKR_TRACKS
+ *    - DST_TRKR_CLUSTER (for tracks-in-jets QA)
  */
-void Fun4All_JetProductionYear2(
+void Fun4All_TrackJetProductionYear2_AuAu(
   const int nEvents = 0,
-  const bool useTwrs = true,
-  const bool useTrks = false,
-  const bool useFlow = false,
-  const std::vector<std::string>& inlists = {
-    "./input/dsts_calo_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_clust_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
-    "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list"
-  },
+  const std::string& inlist = "./input/dsts_track_run2pp-00053877.goldenTrkCaloRun_allSeg.list",
   const std::string& outfile = "DST_JET-00053877-0000.root",
-  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2_trackandcalotest.root",
+  const std::string& outfile_hist = "HIST_JETQA-00053877-0000.year2aa_tracktest.root",
   const std::string& dbtag = "ProdA_2024"
 ) {
 
@@ -90,39 +79,33 @@ void Fun4All_JetProductionYear2(
   // turn on/off DST output and/or QA
   Enable::DSTOUT           = false;
   Enable::QA               = true;
-  Enable::NSJETS_VERBOSITY = 0;
-  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::NSJETS_VERBOSITY);
+  Enable::HIJETS_VERBOSITY = 0;
+  Enable::JETQA_VERBOSITY  = std::max(Enable::VERBOSITY, Enable::HIJETS_VERBOSITY);
 
   // jet reco options
-  Enable::NSJETS         = true;
-  Enable::NSJETS_TOWER   = useTwrs;
-  Enable::NSJETS_TRACK   = useTrks;
-  Enable::NSJETS_PFLOW   = useFlow;
-  NSJETS::is_pp          = true;
-  NSJETS::do_vertex_type = true;
-  NSJETS::vertex_type    = Enable::NSJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
-
-  // make sure HIJetReco inputs are the same
-  // for rho calculation
-  Enable::HIJETS_TOWER = Enable::NSJETS_TOWER;
-  Enable::HIJETS_TRACK = Enable::NSJETS_TRACK;
-  Enable::HIJETS_PFLOW = Enable::NSJETS_PFLOW;
+  Enable::HIJETS         = true;
+  Enable::HIJETS_TOWER   = false;
+  Enable::HIJETS_TRACK   = true;
+  Enable::HIJETS_PFLOW   = false;
+  HIJETS::is_pp          = false;
+  HIJETS::do_vertex_type = true;
+  HIJETS::vertex_type    = Enable::HIJETS_TRACK ? GlobalVertex::SVTX : GlobalVertex::MBD;
 
   // qa options
   JetQA::DoInclusive      = true;
   JetQA::DoTriggered      = true;
-  JetQA::DoPP             = NSJETS::is_pp;
-  JetQA::UseBkgdSub       = false;
+  JetQA::DoPP             = HIJETS::is_pp;
+  JetQA::UseBkgdSub       = true;
   JetQA::RestrictPtToTrig = false;
   JetQA::RestrictEtaByR   = true;
-  JetQA::HasTracks        = Enable::NSJETS_TRACK || Enable::NSJETS_PFLOW;
-  JetQA::HasCalos         = Enable::NSJETS_TOWER || Enable::NSJETS_PFLOW;
+  JetQA::HasTracks        = Enable::HIJETS_TRACK || Enable::HIJETS_PFLOW;
+  JetQA::HasCalos         = Enable::HIJETS_TOWER || Enable::HIJETS_PFLOW;
 
   // tracking options
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = NSJETS::is_pp;
+  TRACKING::pp_mode                     = HIJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 
@@ -131,7 +114,7 @@ void Fun4All_JetProductionYear2(
   se -> Verbosity(1);
 
   // grab 1st file from input lists
-  ifstream    files(inlists.front());
+  ifstream    files(inlist);
   std::string first("");
   std::getline(files, first);
 
@@ -153,12 +136,9 @@ void Fun4All_JetProductionYear2(
   se -> registerSubsystem(flag);
 
   // read in input
-  for (std::size_t iin = 0; iin < inlists.size(); ++iin)
-  {
-    Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst" + std::to_string(iin));
-    indst -> AddListFile(inlists[iin]);
-    se -> registerInputManager(indst);
-  }
+  Fun4AllInputManager* indst = new Fun4AllDstInputManager("indst");
+  indst -> AddListFile(inlist);
+  se -> registerInputManager(indst);
 
   // set up tracking
   if (JetQA::HasTracks)
@@ -177,7 +157,7 @@ void Fun4All_JetProductionYear2(
 
   // do vertex & centrality reconstruction
   Global_Reco();
-  if (!NSJETS::is_pp)
+  if (!HIJETS::is_pp)
   {
     Centrality();
   }
@@ -197,7 +177,7 @@ void Fun4All_JetProductionYear2(
   se -> registerSubsystem(filter);
 
   // do jet reconstruction
-  NoBkgdSubJetReco();
+  HIJetReco();  
 
   // register modules necessary for QA
   if (Enable::QA)

--- a/run3auau/JetProduction/Fun4All_TrackJetProductionYear3.C
+++ b/run3auau/JetProduction/Fun4All_TrackJetProductionYear3.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR3_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR3_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/run3auau/JetProduction/runjets.sh
+++ b/run3auau/JetProduction/runjets.sh
@@ -106,8 +106,8 @@ for infile_ in ${inputs[@]}; do
     outhist=${out0/DST/HIST}
 
     echo ${infile} > input.list
-    echo root.exe -q -b Fun4All_JetProductionYear2.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\)
-         root.exe -q -b Fun4All_JetProductionYear2.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\);  status_f4a=$?
+    echo root.exe -q -b Fun4All_CaloJetProductionYear3.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\)
+         root.exe -q -b Fun4All_CaloJetProductionYear3.C\(${nevents},\"input.list\",\"${outfile}\",\"${outhist}\",\"${dbtag}\"\);  status_f4a=$?
 
     ls -l
 


### PR DESCRIPTION
This PR propagates upstream changes to the year 2 jet production macros, adds the year 3 jet production macros, and updates the production loops to account for these new changes.

## To-Do
- [x] Propagate upstream year 2 macro changes
- [x] Add year 3 (AuAu) macros
- [x] Address 05.21/follow-up items
  - [x] Use single list as input
  - [x] Remove flags
  - [x] Divide macros into a calo jet macro and a track jet macro
- [x] Update production rules where necessary