### PR TITLE
quite if no streaming subsystem is registered

### DIFF
--- a/run3auau/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run3auau/streaming/Fun4All_SingleStream_Combiner.C
@@ -46,6 +46,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 				   const string &input_mvtxfile00 = "mvtx0.list",
 				   const string &input_tpotfile = "tpot.list")
 {
+  int registered_subsystems = 0;
 // GL1 which provides the beam clock reference (if we ran with GL1)
   vector<string> gl1_infile;
   gl1_infile.push_back(input_gl1file);
@@ -123,6 +124,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       intt_sngl->AddListFile(iter);
       in->registerStreamingInput(intt_sngl, InputManagerType::INTT);
       i++;
+      registered_subsystems++;
     }
   }
   i = 0;
@@ -148,6 +150,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       mvtx_sngl->AddListFile(iter);
       in->registerStreamingInput(mvtx_sngl, InputManagerType::MVTX);
       i++;
+      registered_subsystems++;
     }
   }
   i = 0;
@@ -173,6 +176,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       tpc_sngl->AddListFile(iter);
       in->registerStreamingInput(tpc_sngl, InputManagerType::TPC);
       i++;
+      registered_subsystems++;
     }
   }
   i = 0;
@@ -189,10 +193,16 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       mm_sngl->AddListFile(iter);
       in->registerStreamingInput(mm_sngl, InputManagerType::MICROMEGAS);
       i++;
+      registered_subsystems++;
     }
   }
 
   se->registerInputManager(in);
+  if (registered_subsystems == 0)
+  {
+    std::cout << "No streaming readoung input managers resgistered, quitting" << std::endl;
+    gSystem->Exit(1);
+  }
   // StreamingCheck *scheck = new StreamingCheck();
   // scheck->SetTpcBcoRange(130);
   // se->registerSubsystem(scheck);


### PR DESCRIPTION
The macros will now quit if no streaming readout input manager is registered, preventing infinite loops and just running over the gl1