### PR TITLE
fix: handle 24 or 48 prdfs from the arg list

### DIFF
--- a/run3auau/TrackingProduction/Fun4All_SingleJob0.C
+++ b/run3auau/TrackingProduction/Fun4All_SingleJob0.C
@@ -71,7 +71,7 @@ void Fun4All_SingleJob0(
  
   
   int i = 0;
-  
+  int nTpcFiles = 0;
   while(std::getline(ifs,filepath))
     {
       std::cout << "Adding DST with filepath: " << filepath << std::endl; 
@@ -83,6 +83,10 @@ void Fun4All_SingleJob0(
 	   rc->set_IntFlag("RUNNUMBER", runNumber);
 	   rc->set_uint64Flag("TIMESTAMP", runNumber);
         
+	}
+       if(filepath.find("TPC") != std::string::npos)
+	{
+	  nTpcFiles++;
 	}
       std::string inputname = "InputManager" + std::to_string(i);
       auto hitsin = new Fun4AllDstInputManager(inputname);
@@ -119,15 +123,33 @@ void Fun4All_SingleJob0(
   ostringstream ebdcname;
   for(int ebdc = 0; ebdc < 24; ebdc++)
     {
-      for(int endpoint = 0; endpoint <2; endpoint++)
+      if(nTpcFiles == 24)
 	{
 	  ebdcname.str("");
 	  if(ebdc < 10)
 	    {
 	      ebdcname<<"0";
 	    }
-	  ebdcname<<ebdc <<"_"<<endpoint;
+	  ebdcname<<ebdc;
 	  Tpc_HitUnpacking(ebdcname.str());
+	}
+      else if(nTpcFiles == 48)
+	{
+	  for(int endpoint = 0; endpoint <2; endpoint++)
+	    {
+	      ebdcname.str("");
+	      if(ebdc < 10)
+		{
+		  ebdcname<<"0";
+		}
+	      ebdcname<<ebdc <<"_"<<endpoint;
+	      Tpc_HitUnpacking(ebdcname.str());
+	    }
+	}
+      else
+	{
+	  std::cout << "Wrong number of tpc files input! Exiting now." << std::endl;
+	  gSystem->Exit(1);
 	}
     }
 

--- a/run3auau/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run3auau/streaming/Fun4All_SingleStream_Combiner.C
@@ -40,6 +40,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 				   const string &type = "beam",
 				   const int neventsper = 100,
 				   const string &dbtag = "ProdA_2024",
+				   const int nTpcPrdfs = 0,
 				   const string &input_gl1file = "gl1daq.list",
 				   const string &input_tpcfile00 = "tpc00.list",
 				   const string &input_inttfile00 = "intt0.list",
@@ -162,7 +163,20 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       while(std::getline(ifs, filepath))
       {
 	auto pos = filepath.find("ebdc");
-	ebdc = filepath.substr(pos+4, 4);
+	if(nTpcPrdfs == 24)
+	  {
+	    ebdc = filepath.substr(pos+4, 2);
+	  }
+	else if (nTpcPrdfs == 48)
+	  {
+	    ebdc = filepath.substr(pos+4, 4);
+	  }
+	else
+	  {
+	    std::cout << "There is no setup for any non 24 or 48 endpoints. Exiting" << std::endl;
+	    
+	    gSystem->Exit(1);
+	  }
 	break;
       }
 


### PR DESCRIPTION
This fixes the single stream combiner macro to handle 24 or 48 input prdfs as an argument