### PR TITLE
reduce memory for DST readback via split level, keep mbd and gl1 packets

### DIFF
--- a/run2pp/TriggerProduction/Fun4All_New_Prdf_Combiner.C
+++ b/run2pp/TriggerProduction/Fun4All_New_Prdf_Combiner.C
@@ -27,9 +27,10 @@ void Fun4All_New_Prdf_Combiner(int nEvents = 0,
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(1);
-  se->VerbosityDownscale(1000);
+  se->VerbosityDownscale(100000);
   Fun4AllTriggeredInputManager *in = new Fun4AllTriggeredInputManager("Tin");
   SingleTriggeredInput *gl1 = new SingleGl1TriggeredInput("Gl1in");
+  gl1->KeepPackets();
   gl1->AddListFile("gl1daq.list");
 //  gl1->Verbosity(10);
   in->registerGl1TriggeredInput(gl1);
@@ -46,6 +47,10 @@ void Fun4All_New_Prdf_Combiner(int nEvents = 0,
     {
       infile.close();
       input = new SingleTriggeredInput(daqhost);
+      if (strcmp(daqhost,"seb18") == 0)
+      {
+	input->KeepPackets();
+      }
       input->AddListFile(daqlist);
       in->registerTriggeredInput(input);
     }
@@ -65,6 +70,7 @@ void Fun4All_New_Prdf_Combiner(int nEvents = 0,
   clkchk->set_delBadPkts(true);
   se->registerSubsystem(clkchk);
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("dstout",outfile);
+  out->SplitLevel(0);
   out->UseFileRule();
   out->SetNEvents(100000); 
   out->SetClosingScript("stageout.sh");      // script to call on file close (not quite working yet...)


### PR DESCRIPTION
This PR updates the Fun4All_New_Prdf_Combiner macro. Now mbd and gl1 packets are kept during subsequent processing through the fitting. The default splitting leads to a huge memory consumption when reading the produced DSTs. The split level is not set in the macro to be zero (no splitting), reducing the memory needs by about a factor of 5 