### PR TITLE
fix: set dst output to split level 0

### DIFF
--- a/run2pp/streaming/Fun4All_SingleStream_Combiner.C
+++ b/run2pp/streaming/Fun4All_SingleStream_Combiner.C
@@ -213,6 +213,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
   
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out",outfile);
   out->UseFileRule();
+  out->SplitLevel(0);
   out->SetNEvents(neventsper);                       // number of events per output file
   out->SetClosingScript("stageout.sh");      // script to call on file close (not quite working yet...)
   out->SetClosingScriptArgs(outdir);  // additional beyond the name of the file


### PR DESCRIPTION
After a week of debugging what happened in root for memory handling, we finally found that setting the split level to 0 will not cause memory buffering issues in downstream reconstruction jobs when reading in TClonesArrays. This PR updates the pp production macro to call this so we can get this production going again