### PR TITLE
fix: switch to 48 file node name

### DIFF
--- a/run3auau/short/streaming_code/Fun4All_SingleStream_Combiner.C
+++ b/run3auau/short/streaming_code/Fun4All_SingleStream_Combiner.C
@@ -165,7 +165,7 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       while(std::getline(ifs, filepath))
       {
 	auto pos = filepath.find("ebdc");
-	ebdc = filepath.substr(pos+4, 2);
+	ebdc = filepath.substr(pos+4, 4);
 	break;
       }
 


### PR DESCRIPTION
@kkauder Here is the PR, it just needed a node name fix to deal with the ebdc00_0, ebdc00_1... filename types instead of the previous ebdc00, ebdc01... filename types