### PR TITLE
Fix TPC unpacking skipping segment *39

### DIFF
--- a/run3auau/TrackingProduction/Fun4All_SingleJob0.C
+++ b/run3auau/TrackingProduction/Fun4All_SingleJob0.C
@@ -86,7 +86,7 @@ void Fun4All_SingleJob0(
 	}
        if(filepath.find("ebdc") != std::string::npos)
 	{
-	  if(filepath.find("39") == std::string::npos)
+	  if(filepath.find("ebdc39") == std::string::npos)
 	    {
 	      nTpcFiles++;
 	    }


### PR DESCRIPTION
Fixed issue that was skipping segment *39 due to issue with identifying TPOT ebdc. Instead of identifying TPC files as ones that contain "ebdc" but not ones that contain "39", still identify as containing "ebdc" but don't include ones that contain "ebdc39"