### PR TITLE
fix: calib filename scheme

### DIFF
--- a/short/run3auau/streaming_code/Fun4All_SingleStream_Combiner.C
+++ b/short/run3auau/streaming_code/Fun4All_SingleStream_Combiner.C
@@ -225,14 +225,14 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
 	break;
       }
       auto inttcalib = new InttCalib("INTTCalib_" + felix);
-      char hotmapfilename[500];
-      sprintf(hotmapfilename,"./CALIB_HOTMAP_%s.root",type.c_str());
+      char hotmapfilename[500]; 
+      sprintf(hotmapfilename,"./CALIB_HOTMAP_%s-%08i-%05i.root",type.c_str(), runnumber, 0);
       
       char bcomapfilename[500];
-      sprintf(bcomapfilename,"./CALIB_BCOMAP_%s.root", type.c_str());
+      sprintf(bcomapfilename,"./CALIB_BCOMAP_%s-%08i-%05i.root", type.c_str(), runnumber, 0);
 
       char pngfilename[500];
-      sprintf(pngfilename, "./CALIB_PNG_%s.root", type.c_str());
+      sprintf(pngfilename, "./CALIB_PNG_%s-%08i-%05i.root", type.c_str(), runnumber, 0);
       
       inttcalib->SetRawHitContainerName("INTTRAWHIT_" + felix);
       inttcalib->SetHotMapCdbFile(hotmapfilename);


### PR DESCRIPTION
Adds the runnumber/segment to the file name scheme for the calibration files, which was mistakenly left off