### PR TITLE
fix: remove output dsts

### DIFF
--- a/short/run3auau/tracking_code/Fun4All_JobA.C
+++ b/short/run3auau/tracking_code/Fun4All_JobA.C
@@ -254,7 +254,7 @@ void Fun4All_JobA(
   out->AddNode("SvtxTrackSeedContainer");
   out->AddNode("GL1RAWHIT");
 
-  se->registerOutputManager(out);
+  //se->registerOutputManager(out);
 
   auto converter = new TrackSeedTrackMapConverter("SiliconSeedConverter");
   // Default set to full SvtxTrackSeeds. Can be set to

--- a/short/run3auau/tracking_code/Fun4All_SingleJob0.C
+++ b/short/run3auau/tracking_code/Fun4All_SingleJob0.C
@@ -203,7 +203,7 @@ void Fun4All_SingleJob0(
     out->AddNode("LASER_CLUSTER");
     out->AddNode("LAMINATION_CLUSTER");
   }
-  se->registerOutputManager(out);
+  //se->registerOutputManager(out);
 
   se->run(nEvents);
   se->End();


### PR DESCRIPTION
Comment out the dst output manager so that output DSTs are not written for downstream reconstruction right now